### PR TITLE
Export useDataTypes and editors shared components

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,3 +47,5 @@ export { FlowExplorer };
 export { ThemeProvider, ApplicationTheme };
 export { i18n };
 export { useDataTypes };
+// Export editor's shared components
+export * from "./src/editors/_shared";

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ import ShortcutsPlugin, {
 import { ApplicationTheme } from "./src/themes";
 import { ThemeProvider } from "@material-ui/core/styles";
 import i18n from "./src/i18n/i18n";
+// hooks
+import useDataTypes from "./src/editors/_shared/hooks/useDataTypes";
 
 // Exports
 export { BaseApp, installEditor, installTool };
@@ -44,3 +46,4 @@ export { ShortcutsPlugin, getShortcutsTab };
 export { FlowExplorer };
 export { ThemeProvider, ApplicationTheme };
 export { i18n };
+export { useDataTypes };

--- a/src/editors/_shared/index.js
+++ b/src/editors/_shared/index.js
@@ -1,0 +1,17 @@
+import DetailsMenu from "./DetailsMenu/DetailsMenu";
+import CollapsibleHeader from "./CollapsibleHeader/CollapsibleHeader";
+import { HtmlTooltip } from "./HtmlTooltip/HtmlTooltip";
+import KeyValueTable from "./KeyValueTable/KeyValueTable";
+import MaterialTable from "./MaterialTable/MaterialTable";
+import MaterialTree from "./MaterialTree/MaterialTree";
+import Search from "./Search/Search";
+
+export {
+  DetailsMenu,
+  CollapsibleHeader,
+  HtmlTooltip,
+  KeyValueTable,
+  MaterialTable,
+  Search,
+  MaterialTree
+};


### PR DESCRIPTION
- Export `useDataTypes` hook to be used in Annotation Editor
- Export editors shared components