### PR TITLE
FP-1961 - Fix tooltip not showing for function components in MainMenu

### DIFF
--- a/src/plugins/views/MainMenu/MainMenu.jsx
+++ b/src/plugins/views/MainMenu/MainMenu.jsx
@@ -128,10 +128,12 @@ const MainMenu = props => {
         }
         navigationList={MENUS.map(menu => (
           <Tooltip key={menu.name} title={menu.title} placement="right" arrow>
-            {menu.icon({
-              className: classes.icon,
-              onClick: () => menu.getOnClick()
-            })}
+            <span>
+              {menu.icon({
+                className: classes.icon,
+                onClick: () => menu.getOnClick()
+              })}
+            </span>
           </Tooltip>
         ))}
         lowerElement={[


### PR DESCRIPTION
Related to https://movai.atlassian.net/browse/FP-1961

Tooltip was not being shown when icon was being provided a function component instead of a Material UI icon directly.
