### PR TITLE
display docType name instead of docType scope

### DIFF
--- a/src/plugins/views/MainMenu/MainMenu.jsx
+++ b/src/plugins/views/MainMenu/MainMenu.jsx
@@ -120,7 +120,7 @@ const MainMenu = props => {
                     isNew: true
                   });
                 }),
-              element: docType.scope,
+              element: docType.name || docType.scope,
               icon: getIconByScope(docType.scope),
               onClose: true
             }))}

--- a/src/plugins/views/SystemBar/builder/buildSubMenus.js
+++ b/src/plugins/views/SystemBar/builder/buildSubMenus.js
@@ -10,7 +10,7 @@ export const buildNewFileSubmenu = async call => {
     docTypes.forEach(docType => {
       menu.push({
         id: docType.name,
-        title: docType.scope,
+        title: docType.name || docType.scope,
         icon: getIconByScope(docType.scope),
         callback: () => {
           call(PLUGINS.DOC_MANAGER.NAME, PLUGINS.DOC_MANAGER.CALL.CREATE, {


### PR DESCRIPTION
The displayed name for creating new editor is the scope name from BE, we should use a FE defined name. This pull request solves that.