### PR TITLE
FP-2073 : Allow to close untitled document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@
   - [Implement ConfigurationSelector for Configuration Data Type](https://github.com/MOV-AI/frontend-npm-lib-ide/commit/0f063cd3c627e1f0ebd5a0d30967be9cc95931a1)
   - [Fix Configuration Type : Works with parameter syntax and default one](https://github.com/MOV-AI/frontend-npm-lib-ide/commit/4e1502c1724c6ff0d5a8cc327b61fd70f88c77cb)
 - [FP-2031 - Only 1 active selection allowed on Flow Editor](https://movai.atlassian.net/browse/FP-2031)
+- [FP-2073 - When creating a new document, we can't Not save it](https://movai.atlassian.net/browse/FP-2073)
 - [FP-2074 - Fixed a bug that was preventing Containers from triggering the status animation](https://movai.atlassian.net/browse/FP-2074)

--- a/src/plugins/Dialog/Dialog.js
+++ b/src/plugins/Dialog/Dialog.js
@@ -219,7 +219,14 @@ class Dialog extends IDEPlugin {
    * @param {ReactComponent} Component : Component to render custom content in app dialog
    */
   custom(data, Component) {
-    const { title, actions, onSubmit, submitText, ...props } = data;
+    const {
+      title,
+      actions,
+      onSubmit,
+      submitText,
+      message = [],
+      ...props
+    } = data;
     const targetElement = this._handleDialogOpen();
     const closeModal = () =>
       this._handleDialogClose(targetElement, data.onClose);
@@ -233,6 +240,7 @@ class Dialog extends IDEPlugin {
         onSubmit={onSubmit}
         onClose={closeModal}
       >
+        {message}
         <Component {...props} closeModal={closeModal} />
       </AppDialog>,
       targetElement

--- a/src/plugins/views/Tabs/hooks/useTabLayout.js
+++ b/src/plugins/views/Tabs/hooks/useTabLayout.js
@@ -277,14 +277,16 @@ const useTabLayout = (props, dockRef) => {
    * @param {{name: string, scope: string}} docData
    */
   const _discardChanges = useCallback(
-    docData => {
+    (docData, newLayout) => {
       const { id, name, scope } = docData;
       call(
         PLUGINS.DOC_MANAGER.NAME,
         PLUGINS.DOC_MANAGER.CALL.DISCARD_DOC_CHANGES,
         { name, scope }
       ).then(() => {
-        close({ tabId: id });
+        if (!docData.isNew) close({ tabId: id });
+
+        if (newLayout) applyLayout(newLayout);
       });
     },
     [call, applyLayout, getDockFromTabId, removeTabFromStack]
@@ -296,7 +298,7 @@ const useTabLayout = (props, dockRef) => {
    * @param {string} scope : Document scope
    */
   const _closeDirtyTab = useCallback(
-    document => {
+    (document, newLayout) => {
       const { name, scope } = document;
 
       call(PLUGINS.DIALOG.NAME, PLUGINS.DIALOG.CALL.CLOSE_DIRTY_DOC, {
@@ -307,7 +309,7 @@ const useTabLayout = (props, dockRef) => {
             // Save changes and close document
             save: () => _saveDoc(document),
             // Discard changes and close document
-            dontSave: () => _discardChanges(document)
+            dontSave: () => _discardChanges(document, newLayout)
           };
           return action in triggerAction ? triggerAction[action]() : false;
         }
@@ -327,7 +329,7 @@ const useTabLayout = (props, dockRef) => {
       const { name, scope, isNew, isDirty } = tabsById.current.get(tabId);
       if (isDirty && !forceClose) {
         const document = { id: tabId, name, scope, isNew };
-        _closeDirtyTab(document);
+        _closeDirtyTab(document, newLayout);
       } else {
         // Remove doc locally if is new and not dirty
         if (isNew && !isDirty)

--- a/src/stories/components/PluginManager/PluginManager.stories.jsx
+++ b/src/stories/components/PluginManager/PluginManager.stories.jsx
@@ -3,11 +3,24 @@ import PluginManagerIDE from "../../../engine/PluginManagerIDE/PluginManagerIDE"
 import { Button, withNotification } from "@mov-ai/mov-fe-lib-react";
 import { ALERT_SEVERITIES, PLUGINS } from "../../../utils/Constants";
 import Alerts from "../../../plugins/Alerts/Alerts";
+import Dialog from "../../../plugins/Dialog/Dialog";
 
 const TestPluginManager = props => {
   useEffect(() => {
-    const plugin = new Alerts({ name: PLUGINS.ALERT.NAME });
-    PluginManagerIDE.install(PLUGINS.ALERT.NAME, plugin);
+    const plugins = [
+      {
+        profile: { name: PLUGINS.DIALOG.NAME },
+        factory: profile => new Dialog(profile)
+      },
+      {
+        profile: { name: PLUGINS.ALERT.NAME },
+        factory: profile => new Alerts(profile)
+      }
+    ];
+    plugins.forEach(pluginDescription => {
+      const plugin = pluginDescription.factory(pluginDescription.profile);
+      PluginManagerIDE.install(pluginDescription.profile.name, plugin);
+    });
   }, []);
 
   const showAlert = () => {
@@ -17,13 +30,38 @@ const TestPluginManager = props => {
     });
   };
 
+  const showDialog = () => {
+    const Component = () => <h2>Hello World</h2>;
+    PluginManagerIDE.call(
+      PLUGINS.DIALOG.NAME,
+      PLUGINS.DIALOG.CALL.CUSTOM,
+      {
+        title: "Dialog Title",
+        message: "My dialog long text description:",
+        onSubmit: () => {}
+      },
+      Component
+    );
+  };
+
   return (
-    <>
+    <div
+      style={{
+        background: "#202020",
+        color: "white",
+        margin: "-1rem",
+        height: "100vh"
+      }}
+    >
       <h1>Test Plugin Manager</h1>
-      <Button color="primary" onClick={showAlert}>
+      <Button color="primary" onClick={showAlert} style={{ margin: 15 }}>
         Alert
       </Button>
-    </>
+      <Button color="primary" onClick={showDialog} style={{ margin: 15 }}>
+        Dialog
+      </Button>
+      <div id="alertPanel"></div>
+    </div>
   );
 };
 


### PR DESCRIPTION
[FP-2073](https://movai.atlassian.net/browse/FP-2073)

- There was an issue when trying to close an untitled document. It was introduced on PR #31. Fixed, mantaining the same logic that fixed the previous issue.

**UPDATE**:
- My previous fix didn't take into account that saving was having the same issue as per @PedroCristovao-Movai's comment: https://github.com/MOV-AI/frontend-npm-lib-ide/pull/35#pullrequestreview-1138848969
- Also found an issue where when we had a new file (untitled) and just picked "Don't save" when you tried to close the tab or refresh the browser it would also trigger the `onUnload` browser function (because although we closed the tab and discarded changes for `untitled` file it still existed in the store). This was also fixed :heavy_check_mark: 
- Also found an issue where when we had a new file (untitled) and just picked "Save" when you tried to close the tab or refresh the browser it would also trigger the `onUnload` browser function (because although we closed the tab and discarded changes for `untitled` file it still existed in the store). This was also fixed :heavy_check_mark: 