### PR TITLE
FP-2097 : Close tab doesn't remove bookmarks when localStorage is deleted

### DIFF
--- a/src/plugins/views/Tabs/hooks/useTabLayout.js
+++ b/src/plugins/views/Tabs/hooks/useTabLayout.js
@@ -48,6 +48,7 @@ const useTabLayout = (props, dockRef) => {
           const tabData = getToolTabData(tab, tab.tabProps);
           tabsById.current.set(tabData.id, tabData);
           workspaceManager.setTabs(tabsById.current);
+          addTabToStack(tabData, DOCK_POSITIONS.DOCK);
           dockRef.current &&
             dockRef.current.updateTab(toolName, tabData, false);
         }
@@ -270,7 +271,7 @@ const useTabLayout = (props, dockRef) => {
         }
       );
     },
-    [call, applyLayout, getDockFromTabId, removeTabFromStack]
+    [call]
   );
 
   /**
@@ -288,7 +289,7 @@ const useTabLayout = (props, dockRef) => {
         close({ tabId: id });
       });
     },
-    [call, applyLayout, getDockFromTabId, removeTabFromStack]
+    [call]
   );
 
   /**


### PR DESCRIPTION
[FP-2097](https://movai.atlassian.net/browse/FP-2097)

- The welcome page wasn't being added to the Tab Stack when it was first opened. Adding it to the tabStack seems to fix this issue.
- Also removed some dead code.