### PR TITLE
FP-2157 : Added validation for invalidTab to update menus

### DIFF
--- a/src/decorators/withMenuHandler.jsx
+++ b/src/decorators/withMenuHandler.jsx
@@ -16,15 +16,24 @@ const withMenuHandler = Component => {
   const RefComponent = getRefComponent(Component);
 
   return (props, ref) => {
-    const { on, off, profile } = props;
+    const { call, on, off, profile } = props;
     const retryUpdateMenusCounter = useRef(0);
 
     /**
      * Component did mount
      */
     useEffect(() => {
-      on(PLUGINS.TABS.NAME, PLUGINS.TABS.ON.ACTIVE_TAB_CHANGE, data => {
-        if (data.id === profile.name && lastActiveTabName !== data.id) {
+      on(PLUGINS.TABS.NAME, PLUGINS.TABS.ON.ACTIVE_TAB_CHANGE, async data => {
+        const validTab = await call(
+          PLUGINS.TABS.NAME,
+          PLUGINS.TABS.CALL.FIND_TAB,
+          data.id
+        );
+
+        if (
+          !validTab ||
+          (data.id === profile.name && lastActiveTabName !== data.id)
+        ) {
           updateMenus();
           lastActiveTabName = data.id;
         }


### PR DESCRIPTION
[FP-2157](https://movai.atlassian.net/browse/FP-2157)

- If `undefined` or a tab that doesn't exist was passed to `withMenuHandler` it would not update the menus. Now it does.