### PR TITLE
FP-2096: Alternative to Paulo's solution

### DIFF
--- a/src/plugins/views/Explorer/Explorer.jsx
+++ b/src/plugins/views/Explorer/Explorer.jsx
@@ -215,7 +215,7 @@ const Explorer = props => {
    * @param {DocManager} docManager
    */
   const loadDocs = useCallback(docManager => {
-    return setData(_ =>
+    return setData(
       docManager.getStores().map((store, id) => {
         const { name, title, model } = store;
         return {
@@ -261,6 +261,10 @@ const Explorer = props => {
   //========================================================================================
 
   useEffect(() => {
+    // Ugly but needed to compensate for what we believe to be a bug on the
+    // Remixproject library. The on function is being called on mount with
+    // Previously used data.
+    let mounting = true;
     on(PLUGINS.DOC_MANAGER.NAME, PLUGINS.DOC_MANAGER.ON.LOAD_DOCS, loadDocs);
     on(
       PLUGINS.DOC_MANAGER.NAME,
@@ -268,8 +272,11 @@ const Explorer = props => {
       updateDocs
     );
     on(PLUGINS.DOC_MANAGER.NAME, PLUGINS.DOC_MANAGER.ON.DELETE_DOC, data => {
+      if (mounting) return;
       deleteDocument({ documentName: data.name, documentType: data.scope });
     });
+
+    mounting = false;
 
     return () => {
       off(PLUGINS.DOC_MANAGER.NAME, PLUGINS.DOC_MANAGER.ON.LOAD_DOCS);


### PR DESCRIPTION
[FP-2096](https://movai.atlassian.net/browse/FP-2096)

**NOTE**: This is a duplicate solution for [Paulo's PR](https://github.com/MOV-AI/frontend-npm-lib-ide/pull/65)

- We believe there might be a bug in the @remixproject library where it is calling the `on` function with previous data. Might also be something regarding the `off` function not working correctly