### PR TITLE
FP-2253: Added a fix for flow losing interface context

### DIFF
--- a/src/editors/Flow/view/Core/Graph/GraphValidator.js
+++ b/src/editors/Flow/view/Core/Graph/GraphValidator.js
@@ -128,12 +128,21 @@ export default class GraphValidator {
     // Check rule nr. 2 : Links between ports with different message types
     if (linksMismatches) warnings.push(WARNINGS[WARNING_TYPES.LINK_MISMATCH]);
     // Check rule nr. 3 : Links that don't have start or end port
-    if (this.graph.invalidLinks.length)
+    if (this.graph.invalidLinks.length) {
       warnings.push({
         ...WARNINGS[WARNING_TYPES.INVALID_LINKS],
+        onClick: data => {
+          WARNINGS[WARNING_TYPES.INVALID_LINKS].onClick(
+            data,
+            // This is needed because somehow we're losing the
+            // True interface context when we have invalid links
+            this.graph.mInterface
+          );
+        },
         data: this.graph.invalidLinks,
         callback: this.graph.clearInvalidLinks
       });
+    }
 
     return warnings;
   };

--- a/src/editors/Flow/view/Flow.jsx
+++ b/src/editors/Flow/view/Flow.jsx
@@ -215,10 +215,10 @@ export const Flow = (props, ref) => {
    * @param {*} callback
    */
   const deleteInvalidLinks = useCallback(
-    (links, callback) => {
-      links.forEach(link => instance.current.deleteLink(link.id));
+    (links, callback, instance = instance.current) => {
+      links.forEach(link => instance.deleteLink(link.id));
 
-      getMainInterface().graph.clearInvalidLinks().validateFlow();
+      instance.graph.clearInvalidLinks().validateFlow();
 
       callback && callback();
     },
@@ -266,7 +266,7 @@ export const Flow = (props, ref) => {
    * @param {{invalidLinks: Array, callback: Function}} eventData
    */
   const invalidLinksAlert = useCallback(
-    warning => {
+    (warning, customInterface) => {
       const { data: invalidLinks, callback } = warning;
 
       if (invalidLinks.length) {
@@ -276,7 +276,8 @@ export const Flow = (props, ref) => {
           {
             submitText: t("Fix"),
             title: t("InvalidLinksFoundTitle"),
-            onSubmit: () => deleteInvalidLinks(invalidLinks, callback),
+            onSubmit: () =>
+              deleteInvalidLinks(invalidLinks, callback, customInterface),
             invalidLinks
           },
           InvalidLinksWarning
@@ -287,8 +288,8 @@ export const Flow = (props, ref) => {
   );
 
   /**
-   * On Links validation
-   * @param {{invalidLinks: Array, callback: Function}} eventData
+   * On Exposed ports validation
+   * @param {{invalidExposedPorts: Array, callback: Function}} eventData
    */
   const invalidExposedPortsAlert = useCallback(
     warning => {


### PR DESCRIPTION
[FP-2253](https://movai.atlassian.net/browse/FP-2253)

* For some reason we are losing the context of the real interface when fixing invalid links (it actually happens when we open the fix links modal)
* This PR fixes the specific issue with the invalid links fix


**This PR was cherry-picked from PR #98 the code is exactly the same. The issue @PedroCristovao-Movai had with this PR wasn't directly with this PR, was something else that already entered master. When I tested this, I indeed wasn't able to copy/paste nodes with the shortcuts. But after re-merging master everything was working fine.**

[FP-2253]: https://movai.atlassian.net/browse/FP-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ