### PR TITLE
FP-2406: Make menu be able to persist on IDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.0.0 --installs on--> 2.4 IDE-EE / 3.1 IDE-CE
 
+- [FP-2406 - Make menu be able to persist on IDE](https://movai.atlassian.net/browse/FP-2406)
 - [FP-2409 - Added a validation to activateEditor based on the activeTab](https://movai.atlassian.net/browse/FP-2409)
 - [FP-2414 - Fixed an issue where we were always removing the bookmarks, even when not needed](https://movai.atlassian.net/browse/FP-2414)
 - [FP-2250 - Added a debounce and verification for the robot status going offline snackbar](https://movai.atlassian.net/browse/FP-2250)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@mov-ai/mov-fe-lib-ide",
-      "version": "1.0.0-38",
+      "version": "1.0.0-42",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.4.1",
@@ -44,7 +44,7 @@
         "@material-ui/lab": ">=4.0.0-alpha.60",
         "@material-ui/styles": ">=4.11.4",
         "@mov-ai/mov-fe-lib-core": "^1.1.2-9",
-        "@mov-ai/mov-fe-lib-react": "^1.1.2-23",
+        "@mov-ai/mov-fe-lib-react": "^1.1.2-24",
         "@storybook/addon-actions": "^6.5.12",
         "@storybook/addon-essentials": "^6.5.12",
         "@storybook/addon-interactions": "^6.5.12",
@@ -78,8 +78,8 @@
         "@material-ui/icons": ">=4.11.2",
         "@material-ui/lab": ">=4.0.0-alpha.60",
         "@material-ui/styles": ">=4.11.4",
-        "@mov-ai/mov-fe-lib-core": "^1.1.2-7",
-        "@mov-ai/mov-fe-lib-react": "^1.1.2-15",
+        "@mov-ai/mov-fe-lib-core": "^1.1.2-9",
+        "@mov-ai/mov-fe-lib-react": "^1.1.2-23",
         "@tty-pt/styles": "^0.0.3-11",
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0",
@@ -4728,9 +4728,9 @@
       "dev": true
     },
     "node_modules/@mov-ai/mov-fe-lib-react": {
-      "version": "1.1.2-23",
-      "resolved": "https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-react/1.1.2-23/590a7726759a9539140d168f9c723afadeb45f8a",
-      "integrity": "sha512-2SOQWtbId83ZCEtikJME8ffuqGrRo7L7NYeF/qKlF545MZadWcu1ySYowLpQdudiGLQPjcPVBIIJF5UVGaN50w==",
+      "version": "1.1.2-24",
+      "resolved": "https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-react/1.1.2-24/e31cbe2f5e62b9122fe1f028b3b8f3549ab19c8a",
+      "integrity": "sha512-R2dPoeRZIPM3zm2yKaF5rmam27OHryJPCBFpsGxcfhiZCYXYw3mM/gxTb9qDLJVQ4MixOKn/cu0hRdhW1rX+/g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -45799,9 +45799,9 @@
       }
     },
     "@mov-ai/mov-fe-lib-react": {
-      "version": "1.1.2-23",
-      "resolved": "https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-react/1.1.2-23/590a7726759a9539140d168f9c723afadeb45f8a",
-      "integrity": "sha512-2SOQWtbId83ZCEtikJME8ffuqGrRo7L7NYeF/qKlF545MZadWcu1ySYowLpQdudiGLQPjcPVBIIJF5UVGaN50w==",
+      "version": "1.1.2-24",
+      "resolved": "https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-react/1.1.2-24/e31cbe2f5e62b9122fe1f028b3b8f3549ab19c8a",
+      "integrity": "sha512-R2dPoeRZIPM3zm2yKaF5rmam27OHryJPCBFpsGxcfhiZCYXYw3mM/gxTb9qDLJVQ4MixOKn/cu0hRdhW1rX+/g==",
       "dev": true,
       "requires": {
         "@date-io/date-fns": "^1.3.13",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@material-ui/lab": ">=4.0.0-alpha.60",
     "@material-ui/styles": ">=4.11.4",
     "@mov-ai/mov-fe-lib-core": "^1.1.2-9",
-    "@mov-ai/mov-fe-lib-react": "^1.1.2-23",
+    "@mov-ai/mov-fe-lib-react": "^1.1.2-24",
     "@storybook/addon-actions": "^6.5.12",
     "@storybook/addon-essentials": "^6.5.12",
     "@storybook/addon-interactions": "^6.5.12",

--- a/src/App/BaseApp.js
+++ b/src/App/BaseApp.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { Style } from "@mov-ai/mov-fe-lib-react";
 import { Typography } from "@material-ui/core";
 import Grid from "@material-ui/core/Grid";
@@ -49,6 +49,8 @@ function BaseApp(props) {
     dependencies
   } = props;
 
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
   // Style hook
   const classes = appStyles(DEBUG_MODE)();
 
@@ -58,14 +60,25 @@ function BaseApp(props) {
    *                                                                                      */
   //========================================================================================
 
+  const onToggleTheme = () => {
+    setIsMenuOpen(true);
+    handleToggleTheme && handleToggleTheme();
+  };
+
+  const onCloseMenu = () => {
+    setIsMenuOpen(false);
+  };
+
   const mainContextMemo = useMemo(
     () => ({
       handleLogOut,
-      handleToggleTheme,
+      handleToggleTheme: onToggleTheme,
+      isMenuOpen,
+      onCloseMenu,
       selectedTheme: theme,
       isDarkTheme: theme === "dark"
     }),
-    [theme, handleLogOut, handleToggleTheme]
+    [theme, handleLogOut, onToggleTheme]
   );
 
   //========================================================================================
@@ -110,6 +123,7 @@ function BaseApp(props) {
   useEffect(() => {
     if (appProps) setAppProps(appProps);
   }, [appProps]);
+
   //========================================================================================
   /*                                                                                      *
    *                                        Render                                        *
@@ -132,7 +146,7 @@ function BaseApp(props) {
  */
 export function installEditor(editor) {
   const { scope, store, editorPlugin, otherPlugins = [], props = {} } = editor;
-  addEditor({scope, store, plugin: editorPlugin, props});
+  addEditor({ scope, store, plugin: editorPlugin, props });
   // Install other plugins relead to editor
   otherPlugins.forEach(pluginDescription => {
     const plugin = pluginDescription.factory(pluginDescription.profile);

--- a/src/plugins/views/MainMenu/MainMenu.jsx
+++ b/src/plugins/views/MainMenu/MainMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useContext } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import PropTypes from "prop-types";
 import {
@@ -30,8 +30,13 @@ const MainMenu = props => {
   const classes = mainMenuStyles();
   const theme = useTheme();
   const { t } = useTranslation();
-  const { isDarkTheme, handleLogOut, handleToggleTheme } =
-    useContext(MainContext);
+  const {
+    isDarkTheme,
+    isMenuOpen,
+    onCloseMenu,
+    handleLogOut,
+    handleToggleTheme
+  } = useContext(MainContext);
   // Refs
   const MENUS = [
     {
@@ -148,6 +153,8 @@ const MainMenu = props => {
             handleToggleTheme={
               AppSettings.APP_PROPS.SHOW_TOGGLE_THEME ? handleToggleTheme : null
             }
+            isMenuOpen={isMenuOpen}
+            onClose={onCloseMenu}
           />,
           <img
             key={"movaiIcon"}


### PR DESCRIPTION
[FP-2406](https://movai.atlassian.net/browse/FP-2406)

**This merge should only occur after [react #218](https://github.com/MOV-AI/frontend-npm-lib-react/pull/218) gets merged and a new release is out, or it might break the IDE**

* Added a way to make it look like the menu is persistent if it gets unmounted.
* Minor refactor
* This is a hack that had to be done because `MainMenu` keeps getting mount/unmounted due to the complexity of some remix parts. I don't like this, but seems to work without side effects (from what I tested)

[FP-2406]: https://movai.atlassian.net/browse/FP-2406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ