### PR TITLE
FP-2277: Give back focus to Flow Editor after losing focus on some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.0.0 --installs on--> 2.4 IDE-EE / 3.1 IDE-CE
 
+- [FP-2277 - Give back focus to Flow Editor after losing focus on some cases](https://movai.atlassian.net/browse/FP-2277)
 - [FP-2359 - Added a way for the BaseApp keybinds to work](https://movai.atlassian.net/browse/FP-2359)
 - [FP-2438 - No longer saving NodeInstance's Parameter types](https://movai.atlassian.net/browse/FP-2438)
 - [FP-2406 - Make menu be able to persist on IDE](https://movai.atlassian.net/browse/FP-2406)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 1.0.0 --installs on--> 2.4 IDE-EE / 3.1 IDE-CE
 
-- [FP-2277 - Give back focus to Flow Editor after losing focus on some cases](https://movai.atlassian.net/browse/FP-2277)
 - [FP-2359 - Added a way for the BaseApp keybinds to work](https://movai.atlassian.net/browse/FP-2359)
 - [FP-2438 - No longer saving NodeInstance's Parameter types](https://movai.atlassian.net/browse/FP-2438)
 - [FP-2406 - Make menu be able to persist on IDE](https://movai.atlassian.net/browse/FP-2406)
@@ -37,3 +36,4 @@
 - [FP-2481 - Can't start a valid flow in tree view - Start link(s) not found](https://movai.atlassian.net/browse/FP-2481)
 - [FP-2466 - Prevent multiple subscribes in Flow onReady function](https://movai.atlassian.net/browse/FP-2466)
 - [FP-2467 - We are now correctly deleting exposed ports on node deletion](https://movai.atlassian.net/browse/FP-2467)
+- [FP-2277 - Give back focus to Flow Editor after losing focus on some cases](https://movai.atlassian.net/browse/FP-2277)

--- a/src/decorators/withBookmarks.jsx
+++ b/src/decorators/withBookmarks.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useEffect, useRef } from "react";
 import { DRAWER, PLUGINS } from "../utils/Constants";
+import { activateKeyBind } from "../utils/Utils";
 import { usePluginMethods } from "../engine/ReactPlugin/ViewReactPlugin";
 import BookmarkTab from "./Components/BookmarkTab";
 
@@ -30,7 +31,7 @@ const withBookmarks = Component => {
   }
 
   return (props, ref) => {
-    const { anchor, emit } = props;
+    const { anchor, emit, call } = props;
     // React state hooks
     const [bookmarks, setBookmarks] = useState({});
     const [active, setActive] = useState();
@@ -47,6 +48,14 @@ const withBookmarks = Component => {
      *                                                                                      */
     //========================================================================================
 
+    const activateActiveTabEditor = async () => {
+      const tab = await call(
+        PLUGINS.TABS.NAME,
+        PLUGINS.TABS.CALL.GET_ACTIVE_TAB
+      );
+      activateKeyBind(tab.id);
+    };
+
     /**
      * Select bookmark
      * @param {String} name : Bookmark name
@@ -54,6 +63,7 @@ const withBookmarks = Component => {
     const selectBookmark = useCallback(
       name => {
         const drawerView = drawerRef.current.getActiveView();
+        activateActiveTabEditor();
         if (active === name && drawerView === DRAWER.VIEWS.BOOKMARK) {
           drawerRef.current.toggleDrawer();
           return;

--- a/src/editors/Flow/view/Components/Debugging/DependencyInfo.jsx
+++ b/src/editors/Flow/view/Components/Debugging/DependencyInfo.jsx
@@ -4,11 +4,14 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import { LINK_DEPENDENCY } from "../../../../../utils/Constants";
+import { convertToValidString } from "../../../../../utils/Utils";
 
 import { dependencyInfoStyles } from "./styles";
 
-const DependencyInfo = () => {
+const DependencyInfo = props => {
   const [minified, setMinified] = useState(false);
+
+  const { activateKeyBind } = props;
 
   // Translation hook
   const { t } = useTranslation();
@@ -17,6 +20,7 @@ const DependencyInfo = () => {
 
   const toggleMinify = useCallback(() => {
     setMinified(prevState => !prevState);
+    activateKeyBind();
   }, []);
 
   return (
@@ -31,9 +35,12 @@ const DependencyInfo = () => {
             : t("DependencyInfoTitle")}
           <ArrowDropDownIcon />
         </h3>
-        {Object.values(LINK_DEPENDENCY).map((dep, i) => {
+        {Object.values(LINK_DEPENDENCY).map(dep => {
           return (
-            <div key={`${dep.LABEL}_${i}`} className={classes.infoContainer}>
+            <div
+              key={convertToValidString(dep.LABEL)}
+              className={classes.infoContainer}
+            >
               <p>{t(dep.LABEL)}</p>
               <div
                 className={classes.colorChip}

--- a/src/editors/Flow/view/Flow.jsx
+++ b/src/editors/Flow/view/Flow.jsx
@@ -64,6 +64,7 @@ export const Flow = (props, ref) => {
     addKeyBind,
     removeKeyBind,
     activateEditor,
+    activateKeyBind,
     deactivateEditor,
     confirmationAlert,
     contextOptions,
@@ -1186,6 +1187,7 @@ export const Flow = (props, ref) => {
     e => {
       workspaceManager.setFlowIsDebugging(e.target.checked);
       setFlowDebugging(e.target.checked);
+      activateKeyBind();
     },
     [workspaceManager]
   );

--- a/src/editors/Flow/view/Views/BaseFlow.jsx
+++ b/src/editors/Flow/view/Views/BaseFlow.jsx
@@ -25,6 +25,7 @@ const BaseFlow = props => {
     warnings,
     warningsVisibility,
     onReady,
+    activateKeyBind,
     flowDebugging,
     viewMode,
     graphClass,
@@ -107,7 +108,7 @@ const BaseFlow = props => {
           <Warnings warnings={warnings} isVisible={warningsVisibility} />
         )}
       </div>
-      {flowDebugging && <DependencyInfo />}
+      {flowDebugging && <DependencyInfo activateKeyBind={activateKeyBind} />}
     </div>
   );
 };


### PR DESCRIPTION
[FP-2277](https://movai.atlassian.net/browse/FP-2277)

**THIS IS A CHERRY-PICK FROM #140**

* Fixed the issue where clicking on bookmarks caused loss of focus on editor.
* This issue needs to be fixed more in-depth for all editors. This PR also fixes most Flow Editor cases. We need a better filtering from testers where do we need to actually fix the loss of focus.
* Fixed some sonarqube issues

I advise using `activateKeyBind` which editors should have as props (comes from the `withKeybinds` decorator) in the specific scenarios needed,

[FP-2277]: https://movai.atlassian.net/browse/FP-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ