### PR TITLE
FP-2542: Removed code that prevented flow validations from running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.0 --installs on--> 2.4 IDE-EE / 3.1 IDE-CE
 
 
+- [FP-2542 - Removed code that prevented flow validations from running](https://movai.atlassian.net/browse/FP-2542)
 - [FP-2540 - Duplicated code on the new merge request](https://movai.atlassian.net/browse/FP-2540)
 - [FP-2530 - Added ParameterWithType for instances that need to save the type](https://movai.atlassian.net/browse/FP-2530)
 - [FP-2359 - Added a way for the BaseApp keybinds to work](https://movai.atlassian.net/browse/FP-2359)

--- a/src/editors/Flow/view/Core/Graph/GraphBase.js
+++ b/src/editors/Flow/view/Core/Graph/GraphBase.js
@@ -608,7 +608,8 @@ export default class GraphBase {
     const [first, ...rest] = nodeName.split("__");
 
     if (first !== this.mInterface.id)
-      throw new Error("GraphBase.updateNodeStatus: update for other flow? " + first);
+      // throw new Error("GraphBase.updateNodeStatus: update for other flow? " + first);
+      return;
 
     if (rest.length)
       for (let i = 0; i < rest.length; i++) {

--- a/src/editors/Flow/view/Core/Graph/GraphBase.js
+++ b/src/editors/Flow/view/Core/Graph/GraphBase.js
@@ -607,9 +607,7 @@ export default class GraphBase {
     // is this a subflow node?
     const [first, ...rest] = nodeName.split("__");
 
-    if (first !== this.mInterface.id)
-      // throw new Error("GraphBase.updateNodeStatus: update for other flow? " + first);
-      return;
+    if (first !== this.mInterface.id) return;
 
     if (rest.length)
       for (let i = 0; i < rest.length; i++) {

--- a/src/editors/Flow/view/Flow.jsx
+++ b/src/editors/Flow/view/Flow.jsx
@@ -95,7 +95,7 @@ export const Flow = (props, ref) => {
   const [runningFlow, setRunningFlow] = useState("");
   const [warnings, setWarnings] = useState([]);
   const [flowDebugging, setFlowDebugging] = useState();
-  const [warningsVisibility, setWarningsVisibility] = useState(false);
+  const [warningsVisibility, setWarningsVisibility] = useState(true);
   const [viewMode, setViewMode] = useState(FLOW_VIEW_MODE.default);
   const [tooltipConfig, setTooltipConfig] = useState(null);
   const [contextMenuOptions, setContextMenuOptions] = useState(null);
@@ -683,17 +683,6 @@ export const Flow = (props, ref) => {
   //========================================================================================
 
   /**
-   * On flow validation
-   * @param {*} validationWarnings
-   */
-  const onFlowValidated = validationWarnings => {
-    const persistentWarns = validationWarnings.warnings.filter(
-      el => el.isPersistent
-    );
-    setWarnings(persistentWarns);
-  };
-
-  /**
    * Remove Node Bookmark and set selectedNode to null
    */
   const unselectNode = useCallback(() => {
@@ -835,8 +824,8 @@ export const Flow = (props, ref) => {
           el => el.isPersistent
         );
 
-        onFlowValidated({ warnings: persistentWarns });
-      })
+        setWarnings(persistentWarns);
+      });
 
       mainInterface.onLoad = () => setLoading(false);
 

--- a/src/editors/Flow/view/Flow.jsx
+++ b/src/editors/Flow/view/Flow.jsx
@@ -158,11 +158,11 @@ export const Flow = (props, ref) => {
    */
   const startNode = useCallback(
     node => {
-      commandNode("RUN", node, robotSelected).then(() => {
+      commandNode("RUN", node).then(() => {
         node.statusLoading = true;
       });
     },
-    [robotSelected, commandNode]
+    [commandNode]
   );
 
   /**
@@ -171,11 +171,11 @@ export const Flow = (props, ref) => {
    */
   const stopNode = useCallback(
     node => {
-      commandNode("KILL", node, robotSelected).then(() => {
+      commandNode("KILL", node).then(() => {
         node.statusLoading = true;
       });
     },
-    [robotSelected, commandNode]
+    [commandNode]
   );
 
   /**
@@ -486,7 +486,7 @@ export const Flow = (props, ref) => {
         )
       };
     },
-    [MENUS, call, id, instance, openDoc, getMenuComponent, t]
+    [call, id, instance, openDoc, getMenuComponent, t]
   );
 
   /**
@@ -530,7 +530,7 @@ export const Flow = (props, ref) => {
         )
       };
     },
-    [MENUS, call, id, instance, t]
+    [call, id, instance, t]
   );
 
   /**
@@ -608,7 +608,6 @@ export const Flow = (props, ref) => {
       activeBookmark
     );
   }, [
-    MENUS,
     id,
     name,
     instance,
@@ -705,7 +704,7 @@ export const Flow = (props, ref) => {
       MENUS.current.DETAIL.NAME
     );
     selectedNodeRef.current = null;
-  }, [MENUS, call, selectedNodeRef]);
+  }, [call, selectedNodeRef]);
 
   /**
    * On Node Selected
@@ -729,7 +728,7 @@ export const Flow = (props, ref) => {
         }
       }, 300);
     },
-    [MENUS, addNodeMenu, unselectNode, onLinkSelected]
+    [addNodeMenu, unselectNode, onLinkSelected]
   );
 
   /**
@@ -831,15 +830,13 @@ export const Flow = (props, ref) => {
       );
 
       // Subscribe to flow validations
-      interfaceSubscriptionsList.current.push(
-        mainInterface.graph.onFlowValidated.subscribe(evtData => {
-          const persistentWarns = evtData.warnings.filter(
-            el => el.isPersistent
-          );
+      mainInterface.graph.onFlowValidated.subscribe(evtData => {
+        const persistentWarns = evtData.warnings.filter(
+          el => el.isPersistent
+        );
 
-          onFlowValidated({ warnings: persistentWarns });
-        })
-      );
+        onFlowValidated({ warnings: persistentWarns });
+      })
 
       mainInterface.onLoad = () => setLoading(false);
 

--- a/src/editors/Flow/view/Views/BaseFlow.jsx
+++ b/src/editors/Flow/view/Views/BaseFlow.jsx
@@ -103,7 +103,7 @@ const BaseFlow = props => {
           <Loader />
         </Backdrop>
       )}
-      <div className={classes.flowCanvas} id={containerId} tagindex="0">
+      <div className={classes.flowCanvas} id={containerId} tabIndex="0">
         {warnings.length > 0 && (
           <Warnings warnings={warnings} isVisible={warningsVisibility} />
         )}


### PR DESCRIPTION
[FP-2542](https://movai.atlassian.net/browse/FP-2542)

* Removed flowValidations subscriber from the mainInterface subscriptions (as it doesn't need to be unsubbed / resubbed on the `interfaceSubscriptionsList`).
* Fixed an issue where the Flow wasn't being automatically updated when changes were made on other flows that concerned this one (IE: have a flow1 inside the flow2, toggle expose a node's port on flow1, should be visible on flow2 as soon as we change tabs. This was also preventing the flowValidations to ocurr imediately as opposed to having to refresh the page).
* Removed `MENUS` from the dependencies arrays as it's a const initiated outside of the component (and will never be recreated / changed). 
* Prevented the error throw of `"GraphBase.updateNodeStatus: update for other flow? " + first`. This should be a temporary fix, as @quirinpa is already working on the fix.

[FP-2542]: https://movai.atlassian.net/browse/FP-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ