### PR TITLE
[FP-2739] Port properties of the node templates are turning to strings after editing them

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "peerDependencies": {
     "@mov-ai/mov-fe-lib-code-editor": "^1.1.2-11",
     "@mov-ai/mov-fe-lib-core": "^1.2.1-10",
-    "@mov-ai/mov-fe-lib-react": "^1.3.2-12",
+    "@mov-ai/mov-fe-lib-react": "^1.3.2-13",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -79,7 +79,7 @@
     "@codingame/monaco-languageclient": "^0.17.4",
     "@mov-ai/mov-fe-lib-code-editor": "^1.1.2-11",
     "@mov-ai/mov-fe-lib-core": "^1.2.1-10",
-    "@mov-ai/mov-fe-lib-react": "^1.3.2-12",
+    "@mov-ai/mov-fe-lib-react": "^1.3.2-13",
     "@tty-pt/scripts": "^0.6.0-29",
     "http-proxy-middleware": "^3.0.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "web-vitals": "^3.5.2"
   },
   "peerDependencies": {
-    "@mov-ai/mov-fe-lib-code-editor": "^1.1.2-10",
+    "@mov-ai/mov-fe-lib-code-editor": "^1.1.2-11",
     "@mov-ai/mov-fe-lib-core": "^1.2.1-10",
     "@mov-ai/mov-fe-lib-react": "^1.3.2-12",
     "lodash": "^4.17.21",
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@codingame/monaco-languageclient": "^0.17.4",
-    "@mov-ai/mov-fe-lib-code-editor": "^1.1.2-10",
+    "@mov-ai/mov-fe-lib-code-editor": "^1.1.2-11",
     "@mov-ai/mov-fe-lib-core": "^1.2.1-10",
     "@mov-ai/mov-fe-lib-react": "^1.3.2-12",
     "@tty-pt/scripts": "^0.6.0-29",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ devDependencies:
     specifier: ^0.17.4
     version: 0.17.4
   '@mov-ai/mov-fe-lib-code-editor':
-    specifier: ^1.1.2-10
-    version: 1.1.2-10(@codingame/monaco-languageclient@0.17.4)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mov-ai/mov-fe-lib-react@1.3.2-12)(lodash@4.17.21)(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^1.1.2-11
+    version: 1.1.2-11(@codingame/monaco-languageclient@0.17.4)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mov-ai/mov-fe-lib-react@1.3.2-12)(lodash@4.17.21)(react-dom@18.2.0)(react@18.2.0)
   '@mov-ai/mov-fe-lib-core':
     specifier: ^1.2.1-10
     version: 1.2.1-10
@@ -2473,8 +2473,8 @@ packages:
       - react-native
     dev: true
 
-  /@mov-ai/mov-fe-lib-code-editor@1.1.2-10(@codingame/monaco-languageclient@0.17.4)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mov-ai/mov-fe-lib-react@1.3.2-12)(lodash@4.17.21)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-0VskoFNe1BNILWjY79VTE+lQOoH6c71a+wQDU4763SFB1USIhsqvdupUxvFmFhQYoc3xLMGnw/9GOGCivTEIRQ==, tarball: https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-code-editor/1.1.2-10/ad4fdbed3361cf4231991e6d51324f5c851305a6}
+  /@mov-ai/mov-fe-lib-code-editor@1.1.2-11(@codingame/monaco-languageclient@0.17.4)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mov-ai/mov-fe-lib-react@1.3.2-12)(lodash@4.17.21)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-SJ8zE/wy/jg2fDt9UmvF2kUGmNGZoiPrZ0ypBmqSmah1RnQj4Pmz1U5+Gp8dswUhpj/mcj1H2CMl4fndmh2Blg==, tarball: https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-code-editor/1.1.2-11/4aba9bce424ec9dcbfeba39d649fbe10dc704176}
     peerDependencies:
       '@codingame/monaco-languageclient': ^0.17.3
       '@mov-ai/mov-fe-lib-core': ^1.2.1-10
@@ -2488,8 +2488,8 @@ packages:
       '@mov-ai/mov-fe-lib-core': 1.2.1-10
       '@mov-ai/mov-fe-lib-react': 1.3.2-12(@material-table/core@6.3.2)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mui/icons-material@5.15.12)(@mui/material@5.15.12)(@mui/styles@5.15.12)(@mui/x-date-pickers@6.19.6)(@mui/x-tree-view@6.17.0)(csstype@3.1.3)(lodash@4.17.21)(react-dom@18.2.0)(react-mui-dropzone@4.0.7)(react@18.2.0)
       lodash: 4.17.21
-      monaco-editor: 0.47.0
-      monaco-editor-core: 0.47.0
+      monaco-editor: 0.36.1
+      monaco-editor-core: 0.36.1
       normalize-url: 8.0.1
       prop-types: 15.8.1
       react: 18.2.0
@@ -10079,12 +10079,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  /monaco-editor-core@0.47.0:
-    resolution: {integrity: sha512-xho7dsmSYOIek6bkMKQApWHVyoOBQ1eaBIE6CIlER40paTN0r0efrig6Q9QkCacfzIuNNxNjyb1uMVoMpi8gcA==}
+  /monaco-editor-core@0.36.1:
+    resolution: {integrity: sha512-r2XIW2N/uVDa0WhJSnK5hI3ghJADfbX7KqbVEvZGt6kNkKCC1+6evQdpY/6zCehZt8g1C/jTvFMLXvWrLXUxDA==}
     dev: true
 
-  /monaco-editor@0.47.0:
-    resolution: {integrity: sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw==}
+  /monaco-editor@0.36.1:
+    resolution: {integrity: sha512-/CaclMHKQ3A6rnzBzOADfwdSJ25BFoFT0Emxsc4zYVyav5SkK9iA6lEtIeuN/oRYbwPgviJT+t3l+sjFa28jYg==}
     dev: true
 
   /monet@0.9.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,13 +57,13 @@ devDependencies:
     version: 0.17.4
   '@mov-ai/mov-fe-lib-code-editor':
     specifier: ^1.1.2-11
-    version: 1.1.2-11(@codingame/monaco-languageclient@0.17.4)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mov-ai/mov-fe-lib-react@1.3.2-12)(lodash@4.17.21)(react-dom@18.2.0)(react@18.2.0)
+    version: 1.1.2-11(@codingame/monaco-languageclient@0.17.4)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mov-ai/mov-fe-lib-react@1.3.2-13)(lodash@4.17.21)(react-dom@18.2.0)(react@18.2.0)
   '@mov-ai/mov-fe-lib-core':
     specifier: ^1.2.1-10
     version: 1.2.1-10
   '@mov-ai/mov-fe-lib-react':
-    specifier: ^1.3.2-12
-    version: 1.3.2-12(@material-table/core@6.3.2)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mui/icons-material@5.15.12)(@mui/material@5.15.12)(@mui/styles@5.15.12)(@mui/x-date-pickers@6.19.6)(@mui/x-tree-view@6.17.0)(csstype@3.1.3)(lodash@4.17.21)(react-dom@18.2.0)(react-mui-dropzone@4.0.7)(react@18.2.0)
+    specifier: ^1.3.2-13
+    version: 1.3.2-13(@material-table/core@6.3.2)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mui/icons-material@5.15.12)(@mui/material@5.15.12)(@mui/styles@5.15.12)(@mui/x-date-pickers@6.19.6)(@mui/x-tree-view@6.17.0)(csstype@3.1.3)(lodash@4.17.21)(react-dom@18.2.0)(react-mui-dropzone@4.0.7)(react@18.2.0)
   '@tty-pt/scripts':
     specifier: ^0.6.0-29
     version: 0.6.0-29(@swc/core@1.4.6)(@types/node@20.12.3)(@types/react-dom@18.2.18)(@types/react@18.2.51)(@types/testing-library__jest-dom@5.14.9)(canvas@2.11.2)
@@ -2473,7 +2473,7 @@ packages:
       - react-native
     dev: true
 
-  /@mov-ai/mov-fe-lib-code-editor@1.1.2-11(@codingame/monaco-languageclient@0.17.4)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mov-ai/mov-fe-lib-react@1.3.2-12)(lodash@4.17.21)(react-dom@18.2.0)(react@18.2.0):
+  /@mov-ai/mov-fe-lib-code-editor@1.1.2-11(@codingame/monaco-languageclient@0.17.4)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mov-ai/mov-fe-lib-react@1.3.2-13)(lodash@4.17.21)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-SJ8zE/wy/jg2fDt9UmvF2kUGmNGZoiPrZ0ypBmqSmah1RnQj4Pmz1U5+Gp8dswUhpj/mcj1H2CMl4fndmh2Blg==, tarball: https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-code-editor/1.1.2-11/4aba9bce424ec9dcbfeba39d649fbe10dc704176}
     peerDependencies:
       '@codingame/monaco-languageclient': ^0.17.3
@@ -2486,7 +2486,7 @@ packages:
       '@codingame/monaco-jsonrpc': 0.4.1
       '@codingame/monaco-languageclient': 0.17.4
       '@mov-ai/mov-fe-lib-core': 1.2.1-10
-      '@mov-ai/mov-fe-lib-react': 1.3.2-12(@material-table/core@6.3.2)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mui/icons-material@5.15.12)(@mui/material@5.15.12)(@mui/styles@5.15.12)(@mui/x-date-pickers@6.19.6)(@mui/x-tree-view@6.17.0)(csstype@3.1.3)(lodash@4.17.21)(react-dom@18.2.0)(react-mui-dropzone@4.0.7)(react@18.2.0)
+      '@mov-ai/mov-fe-lib-react': 1.3.2-13(@material-table/core@6.3.2)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mui/icons-material@5.15.12)(@mui/material@5.15.12)(@mui/styles@5.15.12)(@mui/x-date-pickers@6.19.6)(@mui/x-tree-view@6.17.0)(csstype@3.1.3)(lodash@4.17.21)(react-dom@18.2.0)(react-mui-dropzone@4.0.7)(react@18.2.0)
       lodash: 4.17.21
       monaco-editor: 0.36.1
       monaco-editor-core: 0.36.1
@@ -2515,8 +2515,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@mov-ai/mov-fe-lib-react@1.3.2-12(@material-table/core@6.3.2)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mui/icons-material@5.15.12)(@mui/material@5.15.12)(@mui/styles@5.15.12)(@mui/x-date-pickers@6.19.6)(@mui/x-tree-view@6.17.0)(csstype@3.1.3)(lodash@4.17.21)(react-dom@18.2.0)(react-mui-dropzone@4.0.7)(react@18.2.0):
-    resolution: {integrity: sha512-k8XI0kg0B59Ygi/OFSdD9ng3y2LgIexx66++alLUBzLc3c9SQTjNkS6IEz4bvbqtH8ExOHE8nRrujVXWW7enOA==, tarball: https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-react/1.3.2-12/55737a11d4716608c643879463eaed23fb1f515b}
+  /@mov-ai/mov-fe-lib-react@1.3.2-13(@material-table/core@6.3.2)(@mov-ai/mov-fe-lib-core@1.2.1-10)(@mui/icons-material@5.15.12)(@mui/material@5.15.12)(@mui/styles@5.15.12)(@mui/x-date-pickers@6.19.6)(@mui/x-tree-view@6.17.0)(csstype@3.1.3)(lodash@4.17.21)(react-dom@18.2.0)(react-mui-dropzone@4.0.7)(react@18.2.0):
+    resolution: {integrity: sha512-rwTzHUuzzvlhwY2uqgnosfkIofNaY46tq3cbhFoUxhe3Rhs6TGYvAWM3niiB2UtLNs+IxPvytYzSWk81X3RNZA==, tarball: https://npm.pkg.github.com/download/@MOV-AI/mov-fe-lib-react/1.3.2-13/e63422360a091c79522ceb88adcf1ad7f1607548}
     peerDependencies:
       '@material-table/core': ^6.3.2
       '@mov-ai/mov-fe-lib-core': ^1.2.1-10

--- a/src/editors/Node/view/Node.jsx
+++ b/src/editors/Node/view/Node.jsx
@@ -87,7 +87,6 @@ export const Node = (props, ref) => {
   //========================================================================================
 
   const updateDescription = useCallback(value => {
-    console.log("Updated description!!")
     if (instance.current) instance.current.setDescription(value);
   }, []);
 
@@ -150,7 +149,16 @@ export const Node = (props, ref) => {
   );
 
   const updateIOPortInputs = useCallback(
-    (value, ioConfigName, direction, ioPortKey, paramName) => {
+    (target, ioConfigName, direction, ioPortKey, paramName) => {
+      // Can be either a checkbox event or a text/number change event
+      let value = target.type === "checkbox" ? target.checked : target.value;
+
+      // Make sure if the input is a number, we save a number to Redis
+      // TO improve: backend can do this type validation
+      if (target.type === "number") {
+        value = parseFloat(value);
+      }
+
       instance.current.setPortParameter(
         ioConfigName,
         direction,

--- a/src/editors/Node/view/Node.jsx
+++ b/src/editors/Node/view/Node.jsx
@@ -87,6 +87,7 @@ export const Node = (props, ref) => {
   //========================================================================================
 
   const updateDescription = useCallback(value => {
+    console.log("Updated description!!")
     if (instance.current) instance.current.setDescription(value);
   }, []);
 

--- a/src/editors/Node/view/components/IOConfig/IOPorts/components/Parameters.jsx
+++ b/src/editors/Node/view/components/IOConfig/IOPorts/components/Parameters.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Grid, TextField } from "@mov-ai/mov-fe-lib-react";
+import { Grid, TextField, Checkbox } from "@mov-ai/mov-fe-lib-react";
 import { FiberManualRecordIcon } from "@mov-ai/mov-fe-lib-react";
 
 import { parametersStyles } from "./styles";
@@ -21,7 +21,7 @@ const Parameters = props => {
   const handleOnChange = useCallback(
     evt => {
       handleIOPortsInputs(
-        evt.target.value,
+        evt.target,
         rowDataName,
         direction,
         ioPort,
@@ -31,6 +31,31 @@ const Parameters = props => {
     [rowDataName, direction, ioPort, param, handleIOPortsInputs]
   );
 
+  // This is a temporary patch, actually Ports data should provide which type the frontend should render
+  // and not this harcoded string. And the backend should have a type validation as well
+  const inputType = () => {
+    if (["latch", "Oneshot"].includes(param)) {
+      return <Checkbox
+        type={"checkbox"}
+        defaultChecked={paramValue}
+        // className={classes.input}
+        onChange={handleOnChange}
+      />;
+    }
+    else {
+      // To improve: MUI has an experimental <NumberInput>
+      return <TextField
+        type={["Frequency", "queue_size"].includes(param) ? "number" : "text"}
+        inputProps={{ "data-testid": "input_parameter" }}
+        disabled={!editable}
+        defaultValue={paramValue}
+        className={classes.input}
+        onChange={handleOnChange}
+      />;
+    }
+
+  }
+
   return (
     <Grid className={classes.gridContainer}>
       <Grid item xs={3} className={classes.titleColumn}>
@@ -38,13 +63,7 @@ const Parameters = props => {
         {`${param}:`}
       </Grid>
       <Grid item xs={9}>
-        <TextField
-          inputProps={{ "data-testid": "input_parameter" }}
-          disabled={!editable}
-          defaultValue={paramValue}
-          className={classes.input}
-          onChange={handleOnChange}
-        />
+        {inputType()}
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
Fixes [FP-2739](https://movai.atlassian.net/browse/FP-2739): Port properties of the node templates are turning to strings after editing them

:warning: This is a temporary fix, because there are hardcoded strings. Actually the types of the parameters should be coming from the PortsData instead of having for example:
```
{
    "name": "out",
    "message": "std_msgs/Empty",
    "callback": null,
    "parameters": {
        "latch": false,
        "queue_size": 1
    }
}
```
We could be having this:
```
{
    "name": "out",
    "message": "std_msgs/Empty",
    "callback": null,
    "parameters": {
        "latch": {"value": false, "type": "boolean"},
        "queue_size": {"value": 1, "type": "number"},
    }
}
```
That way the FE can render any input and enforce the type programatically. If not, the backend could also check the types btw and not break the node functionality

[FP-2739]: https://movai.atlassian.net/browse/FP-2739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ