### PR TITLE
Fixed cannot save in TreeView mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# TBD
+
+- [FP-2754](https://movai.atlassian.net/browse/FP-2754): Control + S doesn't save flow
+- [FP-2653](https://movai.atlassian.net/browse/FP-2653): Nodes disappear after updating a flow parameter in tree view mode
+
 # 1.2.2
 
 - [FP-2713](https://movai.atlassian.net/browse/FP-2713): App version is not defined

--- a/src/editors/Flow/view/Core/Graph/GraphBase.js
+++ b/src/editors/Flow/view/Core/Graph/GraphBase.js
@@ -294,7 +294,12 @@ export default class GraphBase {
       // Let's re-validate the flow
       this.validateFlow();
     } else {
-      // TODO: Update the TreeView a flow is saved
+      // TODO: Update the TreeView when a flow is saved. This function is triggered with onTempladeUpdate
+      // which was designed for when a node template is updated we should update the node instances on the flow.
+      // A line was added to update the Flow when we save a flow. When we have 2 users working on the same flow
+      // this is useful. But if we were on treeView mode, this.deleteNode(nodeId) was deleting all the nodes in the
+      // tree view. So I added this if to prevent that. In the future, updateNodes(), deleteNode(), updateLinks(), etc..
+      // should be generic for either default view or tree view. 
       return;
     }
   };

--- a/src/editors/Flow/view/Core/Graph/GraphBase.js
+++ b/src/editors/Flow/view/Core/Graph/GraphBase.js
@@ -270,26 +270,33 @@ export default class GraphBase {
    * @param {*} data
    */
   onFlowUpdate = data => {
-    // Add missing nodes and update existing
-    this.updateNodes(data.NodeInst, NODE_TYPES.NODE);
-    this.updateNodes(data.Container, NODE_TYPES.CONTAINER);
-    // Get nodes to remove on update
-    const flowNodes = { ...data.NodeInst, ...data.Container };
-    [...this.nodes.keys()].forEach(nodeId => {
-      if (
-        !Object.prototype.hasOwnProperty.call(flowNodes, nodeId) &&
-        nodeId !== "start"
-      ) {
-        this.deleteNode(nodeId);
-      }
-    });
-    // Update links
-    this.updateLinks(data.Links || {});
-    this.nodeStatusUpdated();
-    // Update exposed ports
-    this.loadExposedPorts(data.ExposedPorts || {}, true);
-    // Let's re-validate the flow
-    this.validateFlow();
+    if (this.viewMode === FLOW_VIEW_MODE.default) {
+      // Add missing nodes and update existing
+      this.updateNodes(data.NodeInst, NODE_TYPES.NODE);
+      this.updateNodes(data.Container, NODE_TYPES.CONTAINER);
+      
+      // Get nodes to remove on update
+      const flowNodes = { ...data.NodeInst, ...data.Container };
+      [...this.nodes.keys()].forEach(nodeId => {
+        if (
+          !Object.prototype.hasOwnProperty.call(flowNodes, nodeId) &&
+          nodeId !== "start"
+        ) {
+          this.deleteNode(nodeId);
+        }
+      });
+  
+      // Update links
+      this.updateLinks(data.Links || {});
+      this.nodeStatusUpdated();
+      // Update exposed ports
+      this.loadExposedPorts(data.ExposedPorts || {}, true);
+      // Let's re-validate the flow
+      this.validateFlow();
+    } else {
+      // TODO: Update the TreeView a flow is saved
+      return;
+    }
   };
 
   /**

--- a/src/editors/Flow/view/Core/Graph/GraphTreeView.js
+++ b/src/editors/Flow/view/Core/Graph/GraphTreeView.js
@@ -281,8 +281,7 @@ export default class GraphTreeView extends GraphBase {
    * @param {obj} data node's data that has changed
    */
   updateNode = (_event, _nodeId, _data, _type = TYPES.NODE) => {
-    // TODO: Handle changes in nodes from main flow
-    return;
+    this.addNode(_node, _type, _nodeId);
   };
 
   //========================================================================================

--- a/src/editors/Flow/view/Core/Graph/GraphTreeView.js
+++ b/src/editors/Flow/view/Core/Graph/GraphTreeView.js
@@ -232,7 +232,7 @@ export default class GraphTreeView extends GraphBase {
   addLink = (link, parent) => {
     // link already exists, update
     const _link = this.links.get(link.name);
-
+    
     if (_link) {
       link.updateData({ Dependency: link.Dependency });
       return;
@@ -281,7 +281,7 @@ export default class GraphTreeView extends GraphBase {
    * @param {obj} data node's data that has changed
    */
   updateNode = (_event, _nodeId, _data, _type = TYPES.NODE) => {
-    this.addNode(_node, _type, _nodeId);
+    return;
   };
 
   //========================================================================================

--- a/src/editors/Flow/view/Flow.jsx
+++ b/src/editors/Flow/view/Flow.jsx
@@ -658,6 +658,10 @@ export const Flow = (props, ref) => {
       // Temporary fix to show loading (even though UI still freezes)
       setTimeout(() => {
         setViewMode(newViewMode);
+        addKeyBind(
+          KEYBINDINGS.EDITOR_GENERAL.KEYBINDS.SAVE.SHORTCUTS,
+          ()=>{}
+        );
       }, 100);
     },
     [viewMode, setMode]
@@ -1380,13 +1384,6 @@ export const Flow = (props, ref) => {
         if (viewMode === FLOW_VIEW_MODE.treeView && docData.doc.name === name) {
           const subFlows = mainInterfaceRef.current.graph.subFlows;
 
-          if (!docData.thisDoc.isDirty) {
-            call(PLUGINS.ALERT.NAME, PLUGINS.ALERT.CALL.SHOW, {
-              message: i18n.t(SUCCESS_MESSAGES.SAVED_SUCCESSFULLY),
-              severity: ALERT_SEVERITIES.SUCCESS
-            });
-          }
-
           for (let i = 0, n = subFlows.length; i < n; i++) {
             await call(
               PLUGINS.DOC_MANAGER.NAME,
@@ -1457,6 +1454,7 @@ export const Flow = (props, ref) => {
       removeKeyBind(KEYBINDINGS.FLOW.KEYBINDS.RESET_ZOOM.SHORTCUTS);
       removeKeyBind(KEYBINDINGS.EDITOR_GENERAL.KEYBINDS.CANCEL.SHORTCUTS);
       removeKeyBind(KEYBINDINGS.EDITOR_GENERAL.KEYBINDS.DELETE.SHORTCUTS);
+      removeKeyBind(KEYBINDINGS.EDITOR_GENERAL.KEYBINDS.SAVE.SHORTCUTS);
     };
   }, [
     addKeyBind,

--- a/src/plugins/DocManager/DocManager.js
+++ b/src/plugins/DocManager/DocManager.js
@@ -283,14 +283,17 @@ class DocManager extends IDEPlugin {
     } catch (error) {
       returnMessage.message = error;
       console.warn("failed to save document", error);
-
+      
       this.call(PLUGINS.ALERT.NAME, PLUGINS.ALERT.CALL.SHOW, {
         message: i18n.t(ERROR_MESSAGES.FAILED_TO_SAVE),
         severity: ALERT_SEVERITIES.ERROR
       });
     }
 
-    callback?.(returnMessage);
+    // callback is false when we try to save in TreeView mode
+    if (typeof(callback) === "function") {
+      callback?.(returnMessage);
+    }
     this.saveStack.delete(`${name}_${scope}`);
     return returnMessage;
   }

--- a/src/plugins/DocManager/DocManager.js
+++ b/src/plugins/DocManager/DocManager.js
@@ -283,17 +283,13 @@ class DocManager extends IDEPlugin {
     } catch (error) {
       returnMessage.message = error;
       console.warn("failed to save document", error);
-      
       this.call(PLUGINS.ALERT.NAME, PLUGINS.ALERT.CALL.SHOW, {
         message: i18n.t(ERROR_MESSAGES.FAILED_TO_SAVE),
         severity: ALERT_SEVERITIES.ERROR
       });
     }
 
-    // callback is false when we try to save in TreeView mode
-    if (typeof(callback) === "function") {
-      callback?.(returnMessage);
-    }
+    callback?.(returnMessage);
     this.saveStack.delete(`${name}_${scope}`);
     return returnMessage;
   }
@@ -303,7 +299,7 @@ class DocManager extends IDEPlugin {
    */
   saveActiveEditor() {
     this.call(PLUGINS.TABS.NAME, PLUGINS.TABS.CALL.GET_ACTIVE_TAB).then(tab =>
-      this.save({ name: tab.name, scope: tab.scope }, tab.isNew)
+      this.save({ name: tab.name, scope: tab.scope })
     );
   }
 


### PR DESCRIPTION
[FP-2754](https://movai.atlassian.net/browse/FP-2754): Control + S doesn't save flow
  - There was a random popup when switching between TreeView and Default mode
  - Forcing the focus (keybind) when we switch modes
  - Fix app blowing up when we saved in TreeView (not related to this issue, just needed to do File -> Save Document)
  
[FP-2653](https://movai.atlassian.net/browse/FP-2653): Nodes disappear after updating a flow parameter in tree view mode
  - When we save a Flow the onTemplateUpdate is triggered, and the onFlowUpdate is called, this function isn't ready to deal when the flow is in treeview mode and was deleting the Nodes in the TreeView.

[FP-2754]: https://movai.atlassian.net/browse/FP-2754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FP-2653]: https://movai.atlassian.net/browse/FP-2653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ