### PR TITLE
- [FP-2773]: Scene - opening a scene the info tab on the right is open and empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# TBD
+
 # 1.2.2
 
 - [FP-2773](https://movai.atlassian.net/browse/FP-2773): Scene - opening a scene the info tab on the right is open and empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2.2
 
+- [FP-2773](https://movai.atlassian.net/browse/FP-2773): Scene - opening a scene the info tab on the right is open and empty
 - [FP-2713](https://movai.atlassian.net/browse/FP-2713): App version is not defined
 - [QAP-3963](https://movai.atlassian.net/browse/QAP-3963): Review devcontainer configuration for lib-ide
 - [FP-2840](https://movai.atlassian.net/browse/FP-2840): Update ReadMe's on all apps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # TBD
 
 - [FP-2879](https://movai.atlassian.net/browse/FP-2879): Closing last tab keeps bookmarks
+- [FP-2773](https://movai.atlassian.net/browse/FP-2773): Scene - opening a scene the info tab on the right is open and empty
 - [FP-2882](https://movai.atlassian.net/browse/FP-2882): Clicking in the bar under the documents loses context, not easy to get back
 
 # v1.2.4
@@ -14,7 +15,6 @@
 
 - [FP-2754](https://movai.atlassian.net/browse/FP-2754): Control + S doesn't save flow
 - [FP-2653](https://movai.atlassian.net/browse/FP-2653): Nodes disappear after updating a flow parameter in tree view mode
-- [FP-2773](https://movai.atlassian.net/browse/FP-2773): Scene - opening a scene the info tab on the right is open and empty
 
 # v1.2.2
 

--- a/src/decorators/withBookmarks.jsx
+++ b/src/decorators/withBookmarks.jsx
@@ -34,12 +34,11 @@ const withBookmarks = Component => {
     const { anchor, emit, call } = props;
     // React state hooks
     const [bookmarks, setBookmarks] = useState({});
-    const firstKey = useMemo(() => Object.keys(bookmarks)[0] ?? false, [bookmarks]);
     const [active, setActive] = useState();
-    const renderedView = useMemo(
-      () => bookmarks[active || firstKey]?.view || [],
-      [active, bookmarks, firstKey]
-    );
+    const renderedView = useMemo(() => {
+      const firstKey = Object.keys(bookmarks)[0] ?? false;
+      return bookmarks[active || firstKey]?.view || [];
+    }, [active, bookmarks, firstKey]);
     // Refs
     const drawerRef = useRef();
     const oppositeSide = getOpositeSide(anchor);

--- a/src/decorators/withBookmarks.jsx
+++ b/src/decorators/withBookmarks.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useRef } from "react";
+import React, { useCallback, useState, useMemo, useEffect, useRef } from "react";
 import { DRAWER, PLUGINS } from "../utils/Constants";
 import { activateKeyBind } from "../utils/Utils";
 import { usePluginMethods } from "../engine/ReactPlugin/ViewReactPlugin";
@@ -34,8 +34,12 @@ const withBookmarks = Component => {
     const { anchor, emit, call } = props;
     // React state hooks
     const [bookmarks, setBookmarks] = useState({});
+    const firstKey = useMemo(() => Object.keys(bookmarks)[0] ?? false, [bookmarks]);
     const [active, setActive] = useState();
-    const [renderedView, setRenderedView] = useState(<></>);
+    const renderedView = useMemo(
+      () => bookmarks[active || firstKey]?.view || [],
+      [active, bookmarks, firstKey]
+    );
     // Refs
     const drawerRef = useRef();
     const oppositeSide = getOpositeSide(anchor);
@@ -133,8 +137,8 @@ const withBookmarks = Component => {
      * Reset bookmarks (remove all)
      */
     const resetBookmarks = useCallback(() => {
+      setActive(true);
       setBookmarks({});
-      setRenderedView([]);
       // It turns out that we shouldn't close the drawer on reset,
       // If it comes back that we need to close the drawer on tab change
       // This needs to be revisited.
@@ -166,7 +170,6 @@ const withBookmarks = Component => {
     useEffect(() => {
       if (bookmarks[active]) {
         const view = bookmarks[active].view;
-        setRenderedView(view);
         drawerRef.current.activateBookmarkView();
       }
     }, [active, bookmarks]);

--- a/src/decorators/withBookmarks.jsx
+++ b/src/decorators/withBookmarks.jsx
@@ -38,7 +38,7 @@ const withBookmarks = Component => {
     const renderedView = useMemo(() => {
       const firstKey = Object.keys(bookmarks)[0] ?? false;
       return bookmarks[active || firstKey]?.view || [];
-    }, [active, bookmarks, firstKey]);
+    }, [active, bookmarks]);
     // Refs
     const drawerRef = useRef();
     const oppositeSide = getOpositeSide(anchor);

--- a/src/decorators/withBookmarks.jsx
+++ b/src/decorators/withBookmarks.jsx
@@ -36,8 +36,8 @@ const withBookmarks = Component => {
     const [bookmarks, setBookmarks] = useState({});
     const [active, setActive] = useState();
     const renderedView = useMemo(() => {
-      const firstKey = Object.keys(bookmarks)[0] ?? false;
-      return bookmarks[active || firstKey]?.view || [];
+      const firstKey = Object.keys(bookmarks)[0];
+      return bookmarks[active || firstKey]?.view || null;
     }, [active, bookmarks]);
     // Refs
     const drawerRef = useRef();
@@ -136,7 +136,7 @@ const withBookmarks = Component => {
      * Reset bookmarks (remove all)
      */
     const resetBookmarks = useCallback(() => {
-      setActive(true);
+      setActive("non-existent");
       setBookmarks({});
       // It turns out that we shouldn't close the drawer on reset,
       // If it comes back that we need to close the drawer on tab change


### PR DESCRIPTION
- [FP-2773](https://movai.atlassian.net/browse/FP-2773): Scene - opening a scene the info tab on the right is open and empty
  - Depends on:
    - https://github.com/MOV-AI/frontend-npm-lib-scene/pull/282
    - https://github.com/MOV-AI/frontend-npm-ide/pull/596
    
 
[Gravação de ecrã a partir de 31-07-2024 13:52:25.webm](https://github.com/user-attachments/assets/5edcd29c-b530-4b3f-a675-42f8ef74fa41)

[FP-2773]: https://movai.atlassian.net/browse/FP-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ