### PR TITLE
FP-2603: Fixed issue where active tab change was being wrongfully triggered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+# TBD
+
+- [FP-2603](https://movai.atlassian.net/browse/FP-2603): Properties dropdown closing after edit - active tab change is being wrongfully triggered
+
 # 1.2.3
 
 - [FP-2754](https://movai.atlassian.net/browse/FP-2754): Control + S doesn't save flow
 - [FP-2653](https://movai.atlassian.net/browse/FP-2653): Nodes disappear after updating a flow parameter in tree view mode
-- [FP-2603](https://movai.atlassian.net/browse/FP-2603): Fixed issue where active tab change was being wrongfully triggered
 
 # 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FP-2754](https://movai.atlassian.net/browse/FP-2754): Control + S doesn't save flow
 - [FP-2653](https://movai.atlassian.net/browse/FP-2653): Nodes disappear after updating a flow parameter in tree view mode
+- [FP-2603](https://movai.atlassian.net/browse/FP-2603): Fixed issue where active tab change was being wrongfully triggered
 
 # 1.2.2
 

--- a/src/engine/ReactPlugin/EditorReactPlugin.js
+++ b/src/engine/ReactPlugin/EditorReactPlugin.js
@@ -93,6 +93,9 @@ export function withEditorPlugin(ReactComponent, methods = []) {
           data.id
         );
 
+        // This check goes through every open tab checking it's id
+        // towards data.id (which comes from the ACTIVE_TAB_CHANGE broadcast)
+        // When we find the tab with the id that we want to reset, we reset it
         if (validTab && data.id === id) {
           // We should reset bookmarks when changing tabs. Right? And Left too :D
           PluginManagerIDE.resetBookmarks();

--- a/src/plugins/views/Tabs/hooks/useTabLayout.js
+++ b/src/plugins/views/Tabs/hooks/useTabLayout.js
@@ -666,6 +666,7 @@ const useTabLayout = (props, dockRef) => {
    */
   const onLayoutChange = useCallback(
     (newLayout, tabId, direction) => {
+      const isActuallyTabChange = activeTabId.current !== tabId;
       const dock = getDockFromTabId(tabId);
       const tabData = tabsById.current.get(tabId);
       let newActiveTabId = tabId;
@@ -688,8 +689,10 @@ const useTabLayout = (props, dockRef) => {
       // Emit new active tab id
       if (!tabId) return;
 
-      activeTabId.current = newActiveTabId;
-      emit(PLUGINS.TABS.ON.ACTIVE_TAB_CHANGE, { id: newActiveTabId });
+      if(isActuallyTabChange){
+        activeTabId.current = newActiveTabId;
+        emit(PLUGINS.TABS.ON.ACTIVE_TAB_CHANGE, { id: newActiveTabId });
+      }
     },
     [
       getDockFromTabId,


### PR DESCRIPTION
[FP-2603](https://movai.atlassian.net/browse/FP-2603)

* Fixed issue that was causing active tab change to be called when we did some changes in the same tab.

[FP-2603]: https://movai.atlassian.net/browse/FP-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ