### PR TITLE
FP-2879: Also resetBoomarks when we have an invalidTab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 - [FP-2603](https://movai.atlassian.net/browse/FP-2603): Properties dropdown closing after edit - active tab change is being wrongfully triggered
 - [QAP-4055](https://movai.atlassian.net/browse/QAP-4055): Forward test coverage for lib-ide
+- [FP-2879](https://movai.atlassian.net/browse/FP-2879): Also resetBoomarks when we have an invalidTab
 
 # 1.2.3
 
 - [FP-2754](https://movai.atlassian.net/browse/FP-2754): Control + S doesn't save flow
 - [FP-2653](https://movai.atlassian.net/browse/FP-2653): Nodes disappear after updating a flow parameter in tree view mode
-- [FP-2879](https://movai.atlassian.net/browse/FP-2879): Also resetBoomarks when we have an invalidTab
 
 # 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FP-2754](https://movai.atlassian.net/browse/FP-2754): Control + S doesn't save flow
 - [FP-2653](https://movai.atlassian.net/browse/FP-2653): Nodes disappear after updating a flow parameter in tree view mode
+- [FP-2879](https://movai.atlassian.net/browse/FP-2879): Also resetBoomarks when we have an invalidTab
 
 # 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+# TBD
+
+- [FP-2879](https://movai.atlassian.net/browse/FP-2879): Closing last tab keeps bookmarks
+
 # v1.2.4
 
 - [FP-2603](https://movai.atlassian.net/browse/FP-2603): Properties dropdown closing after edit - active tab change is being wrongfully triggered
 - [FP-2874](https://movai.atlassian.net/browse/FP-2874): IDE app version not correct
 - [QAP-4055](https://movai.atlassian.net/browse/QAP-4055): Forward test coverage for lib-ide
-- [FP-2879](https://movai.atlassian.net/browse/FP-2879): Closing last tab keeps bookmarks
 - [FP-2529](https://movai.atlassian.net/browse/FP-2529): Add data-testid to links. Added unit testing to BaseLink
 
 # v1.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - [FP-2603](https://movai.atlassian.net/browse/FP-2603): Properties dropdown closing after edit - active tab change is being wrongfully triggered
 - [QAP-4055](https://movai.atlassian.net/browse/QAP-4055): Forward test coverage for lib-ide
-- [FP-2879](https://movai.atlassian.net/browse/FP-2879): Also resetBoomarks when we have an invalidTab
+- [FP-2879](https://movai.atlassian.net/browse/FP-2879): Closing last tab keeps bookmarks
 
 # 1.2.3
 

--- a/src/engine/ReactPlugin/EditorReactPlugin.js
+++ b/src/engine/ReactPlugin/EditorReactPlugin.js
@@ -93,7 +93,8 @@ export function withEditorPlugin(ReactComponent, methods = []) {
           data.id
         );
 
-        if (validTab && data.id === id) {
+
+        if (!validTab || (validTab && data.id === id)) {
           // We should reset bookmarks when changing tabs. Right? And Left too :D
           PluginManagerIDE.resetBookmarks();
           updateRightMenu();

--- a/src/plugins/views/Tabs/hooks/useTabLayout.js
+++ b/src/plugins/views/Tabs/hooks/useTabLayout.js
@@ -29,7 +29,7 @@ const useTabLayout = (props, dockRef) => {
   const tabsById = useRef(new Map());
   const [layout, setLayout] = useState({ ...DEFAULT_LAYOUT });
   const { addTabToStack, removeTabFromStack, getNextTabFromStack } =
-    useTabStack(workspaceManager);
+    useTabStack(workspaceManager, layout);
 
   //========================================================================================
   /*                                                                                      *
@@ -687,7 +687,7 @@ const useTabLayout = (props, dockRef) => {
       }
       // Emit new active tab id
       if (!tabId) return;
-
+      
       activeTabId.current = newActiveTabId;
       emit(PLUGINS.TABS.ON.ACTIVE_TAB_CHANGE, { id: newActiveTabId });
     },

--- a/src/plugins/views/Tabs/hooks/useTabLayout.js
+++ b/src/plugins/views/Tabs/hooks/useTabLayout.js
@@ -29,7 +29,7 @@ const useTabLayout = (props, dockRef) => {
   const tabsById = useRef(new Map());
   const [layout, setLayout] = useState({ ...DEFAULT_LAYOUT });
   const { addTabToStack, removeTabFromStack, getNextTabFromStack } =
-    useTabStack(workspaceManager, layout);
+    useTabStack(workspaceManager);
 
   //========================================================================================
   /*                                                                                      *

--- a/src/plugins/views/Tabs/hooks/useTabLayout.js
+++ b/src/plugins/views/Tabs/hooks/useTabLayout.js
@@ -49,7 +49,15 @@ const useTabLayout = (props, dockRef) => {
           const tabData = getToolTabData(tab, tab.tabProps);
           tabsById.current.set(tabData.id, tabData);
           workspaceManager.setTabs(tabsById.current);
-          addTabToStack(tabData, DOCK_POSITIONS.DOCK);
+
+          // This fixes an issue where on first load a non editor tab
+          // was being added to the tabStack (HomeTab) and that meant
+          // that the last tab to enter tabStack would always be
+          // HomeTab, instead of the correct last tab
+          if(!firstLoad.current){
+            addTabToStack(tabData, DOCK_POSITIONS.DOCK);
+          }
+
           dockRef.current?.updateTab?.(toolName, tabData, false);
         }
       });

--- a/src/plugins/views/Tabs/hooks/useTabStack.js
+++ b/src/plugins/views/Tabs/hooks/useTabStack.js
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { DOCK_POSITIONS } from "../../../../utils/Constants";
 import { runBeforeUnload } from "../../../../utils/Utils";
 
-const useTabStack = workspaceManager => {
-  const tabStack = React.useRef({});
+const useTabStack = (workspaceManager, layout) => {
+  const tabStack = useRef({});
 
   //========================================================================================
   /*                                                                                      *
@@ -19,10 +19,45 @@ const useTabStack = workspaceManager => {
     const newStack = {};
     for (const dock in thisStack) {
       const dockStack = thisStack[dock];
-      newStack[dock] = dockStack.filter(tab => !tab.isNew);
+      newStack[dock] = dockStack.filter(tab => !tab?.isNew);
     }
     workspaceManager.setTabStack(newStack);
   }, [workspaceManager]);
+
+  /**
+   * @private Sanitizes all tabs in docks 
+   * (What would happen sometimes is: For some reason
+   * You could have multiple tabs in the tab stack 
+   * that didn't actually exist in the layout,
+   * This way, on mount we will always sanitize the tabStack
+   * to only have the same tabs that exist in the layout)
+   */
+  const sanitizeStackTabs = useCallback(() => {
+    if(!layout) return;
+    // const dockboxTabs = layout.dockbox.children[0]?.tabs;
+    // const floatboxTabs = layout.floatbox.children[0]?.tabs;
+    // const maxboxTabs = layout.maxbox.children[0]?.tabs;
+    // const windowboxTabs = layout.windowbox.children[0]?.tabs;
+
+    Object.keys(tabStack.current).forEach(key => {
+      tabStack.current[key] = layout[key].children[0]?.tabs.map(actualTab => {
+        tabStack.current[key].find(stackTab => stackTab.id === actualTab.id);
+      })
+    })
+    // tabStack.current.dockbox = dockboxTabs?.map(actualTab => 
+    //   tabStack.current.dockbox.find(stackTab => stackTab.id === actualTab.id)
+    // );
+    // tabStack.current.floatbox = floatboxTabs?.map(actualTab => 
+    //   tabStack.current.floatbox.find(stackTab => stackTab.id === actualTab.id)
+    // );
+    // tabStack.current.maxbox = maxboxTabs?.map(actualTab => 
+    //   tabStack.current.maxbox.find(stackTab => stackTab.id === actualTab.id)
+    // );
+    // tabStack.current.windowbox = windowboxTabs?.map(actualTab => 
+    //   tabStack.current.windowbox.find(stackTab => stackTab.id === actualTab.id)
+    // );
+
+  }, [layout])
 
   //========================================================================================
   /*                                                                                      *
@@ -38,7 +73,7 @@ const useTabStack = workspaceManager => {
   const removeTabFromStack = useCallback(
     (tabId, dock = DOCK_POSITIONS.DOCK) => {
       const thisStack = tabStack.current[dock] || [];
-      const newStack = thisStack.filter(tab => tab.id !== tabId);
+      const newStack = thisStack.filter(tab => tab?.id !== tabId);
       tabStack.current[dock] = newStack;
       workspaceManager.setTabStack(tabStack.current);
     },
@@ -79,6 +114,8 @@ const useTabStack = workspaceManager => {
 
   useEffect(() => {
     tabStack.current = workspaceManager.getTabStack();
+    // Let's sanitize the stacktabs on mount 
+    sanitizeStackTabs();
     // Before unload app, remove all "untitled" tabs from stack
     runBeforeUnload(removeNewTabsFromStack);
   }, [workspaceManager, removeNewTabsFromStack]);

--- a/src/plugins/views/Tabs/hooks/useTabStack.js
+++ b/src/plugins/views/Tabs/hooks/useTabStack.js
@@ -4,7 +4,7 @@ import { runBeforeUnload } from "../../../../utils/Utils";
 
 const useTabStack = (workspaceManager) => {
   const tabStack = useRef({});
-
+  
   //========================================================================================
   /*                                                                                      *
    *                                    Private Methods                                   *

--- a/src/plugins/views/Tabs/hooks/useTabStack.js
+++ b/src/plugins/views/Tabs/hooks/useTabStack.js
@@ -34,28 +34,12 @@ const useTabStack = (workspaceManager, layout) => {
    */
   const sanitizeStackTabs = useCallback(() => {
     if(!layout) return;
-    // const dockboxTabs = layout.dockbox.children[0]?.tabs;
-    // const floatboxTabs = layout.floatbox.children[0]?.tabs;
-    // const maxboxTabs = layout.maxbox.children[0]?.tabs;
-    // const windowboxTabs = layout.windowbox.children[0]?.tabs;
 
     Object.keys(tabStack.current).forEach(key => {
       tabStack.current[key] = layout[key].children[0]?.tabs.map(actualTab => {
         tabStack.current[key].find(stackTab => stackTab.id === actualTab.id);
       })
-    })
-    // tabStack.current.dockbox = dockboxTabs?.map(actualTab => 
-    //   tabStack.current.dockbox.find(stackTab => stackTab.id === actualTab.id)
-    // );
-    // tabStack.current.floatbox = floatboxTabs?.map(actualTab => 
-    //   tabStack.current.floatbox.find(stackTab => stackTab.id === actualTab.id)
-    // );
-    // tabStack.current.maxbox = maxboxTabs?.map(actualTab => 
-    //   tabStack.current.maxbox.find(stackTab => stackTab.id === actualTab.id)
-    // );
-    // tabStack.current.windowbox = windowboxTabs?.map(actualTab => 
-    //   tabStack.current.windowbox.find(stackTab => stackTab.id === actualTab.id)
-    // );
+    });
 
   }, [layout])
 

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -175,7 +175,7 @@ export function runBeforeUnload(callback, ...args) {
   const onAppUnload = window.onbeforeunload;
   // Set new beforeunload method with given callback
   window.onbeforeunload = event => {
-    callback?.(...args, event);
+    callback?.(event, ...args);
     return onAppUnload(event);
   };
 }

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -170,12 +170,12 @@ export function simulateMouseClick(element) {
  * Trigger callback before unload app
  * @param {function} callback
  */
-export function runBeforeUnload(callback) {
+export function runBeforeUnload(callback, ...args) {
   // Previous beforeunload method
   const onAppUnload = window.onbeforeunload;
   // Set new beforeunload method with given callback
   window.onbeforeunload = event => {
-    callback?.(event);
+    callback?.(...args, event);
     return onAppUnload(event);
   };
 }

--- a/src/utils/Workspace.js
+++ b/src/utils/Workspace.js
@@ -25,6 +25,9 @@ class Workspace {
       (a, k) => ({ ...a, [k]: [] }),
       {}
     );
+    // Since we are always setting the DEFAULT_TABS
+    // It makes sense to add them to the tabStack as well.
+    this.defaultTabStack[DOCK_POSITIONS.DOCK] = [...DEFAULT_TABS.values()];
     this.tabStack = this.getTabStack();
     this.recentDocuments = this.getRecentDocuments();
     this.selectedRobot = this.getSelectedRobot();
@@ -116,7 +119,7 @@ class Workspace {
    */
   getTabStack() {
     const tabStack = this.storage.get(this.TAB_STACK_KEY) ?? this.defaultTabStack;
-    
+
     // Convert tabStack to new format
     for (const dock in tabStack) {
       tabStack[dock] = tabStack[dock].map(tab => ({

--- a/src/utils/Workspace.js
+++ b/src/utils/Workspace.js
@@ -21,11 +21,11 @@ class Workspace {
     this.layoutAndTabs = this.getLayoutAndTabs();
     this.layout = this.layoutAndTabs[0];
     this.tabs = this.layoutAndTabs[1];
-    this.tabStack = this.getTabStack();
     this.defaultTabStack = Object.values(DOCK_POSITIONS).reduce(
       (a, k) => ({ ...a, [k]: [] }),
       {}
     );
+    this.tabStack = this.getTabStack();
     this.recentDocuments = this.getRecentDocuments();
     this.selectedRobot = this.getSelectedRobot();
     this.defaultRecentDocuments = [];
@@ -114,12 +114,12 @@ class Workspace {
    * Get information about current open tab stack from local storage
    * @returns {Object} tabStack
    */
-  getTabStack(defaultTabStack = this.defaultTabStack) {
-    const tabStack = this.storage.get(this.TAB_STACK_KEY) ?? defaultTabStack;
+  getTabStack() {
+    const tabStack = this.storage.get(this.TAB_STACK_KEY) ?? this.defaultTabStack;
+    
     // Convert tabStack to new format
     for (const dock in tabStack) {
-      // Added filter because sometimes we had null values?!
-      tabStack[dock] = tabStack[dock].filter(x => x).map(tab => ({
+      tabStack[dock] = tabStack[dock].map(tab => ({
         id: tab.id || tab,
         isNew: tab.isNew
       }));

--- a/src/utils/Workspace.js
+++ b/src/utils/Workspace.js
@@ -118,7 +118,8 @@ class Workspace {
     const tabStack = this.storage.get(this.TAB_STACK_KEY) ?? defaultTabStack;
     // Convert tabStack to new format
     for (const dock in tabStack) {
-      tabStack[dock] = tabStack[dock].map(tab => ({
+      // Added filter because sometimes we had null values?!
+      tabStack[dock] = tabStack[dock].filter(x => x).map(tab => ({
         id: tab.id || tab,
         isNew: tab.isNew
       }));


### PR DESCRIPTION
[FP-2879](https://movai.atlassian.net/browse/FP-2879)

* ~~Added some sanitization to tabStack onMount~~ This has been removed as was causing other issues and the end result wasn't nearly worth it. I did, however, caught an issue where defaultTabStack was being initialized after being called in `workspace.getTabStack()`.
* We are now also reseting boomarks when we have an invalidTab (ie: there's no more tabs)
* Added a filter before we get the tab stack `getTabStack` to clean out `null` or `undefined` values.

The issue that was happening where sometimes we didn't have tabs and the UI would be weird, it might be solved in this PR (not sure as it's not easily replicable.)

**The actual solution to this ticket's issue is efectively in `src/engine/ReactPlugin/EditorReactPlugin.js` in line 97** 
The rest are quality of life improvements, sanitizations and checks.

[FP-2879]: https://movai.atlassian.net/browse/FP-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ