### PR TITLE
BP-1200: Fix subscription to doc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-2946](https://movai.atlassian.net/browse/FP-2946): Deleting the "Label" filter from lib-ide BaseStore results in a 500 response in certain conditions
+
 # v1.2.7
 
 - [FP-2787](https://movai.atlassian.net/browse/FP-2787): IDE - Topics - Can't open multiple Topics tabs

--- a/src/store/BaseStore.js
+++ b/src/store/BaseStore.js
@@ -171,9 +171,20 @@ class BaseStore extends StorePluginManager {
   }
 
   _onSetDoc(doc) {
-    if (!this.getDoc(doc.name)) {
-      this.newDoc(doc.name);
+    const docInst = this.getDoc(doc.name);
+    if (!docInst) {
+      const newDoc = this.newDoc(doc.name);
+      newDoc
+        .enableObservables(false)
+        .setIsNew(false)
+        .setIsLoaded(false)
+        .setDirty(false)
+        .enableObservables(true);
     }
+
+    // if the doc is existing and not dirty, we should update
+    // it but that is non-trivial. We should open a new issue
+    // for it
   }
 
   /**

--- a/src/store/BaseStore.js
+++ b/src/store/BaseStore.js
@@ -24,7 +24,7 @@ class BaseStore extends StorePluginManager {
     this._scope = model.SCOPE;
     this._name = name || "Store";
     this._title = title || "Generic Store";
-    this.pattern = pattern || { Scope: this.scope, Name: "*", Label: "*" };
+    this.pattern = pattern || { Scope: this.scope, Name: "*"}
     this.observer = observer;
     this.docManager = docManager;
     this.protectedDocs = [];

--- a/src/store/DBSubscriber/DBSubscriber.js
+++ b/src/store/DBSubscriber/DBSubscriber.js
@@ -79,8 +79,9 @@ class DBSubscriber extends StoreAbstractPlugin {
   onUpdate(data) {
     clearTimeout(this[symbols.timer]);
 
+    let docName = Object.keys(data["key"][this.scope])[0];
     this[symbols.timer] = setTimeout(
-      () => this.updateDocument(data.patterns[0].Name),
+      () => this.updateDocument(docName),
       DEBOUNCE_TIME
     );
   }


### PR DESCRIPTION
The main change in this PR is changing the subscription pattern to get updates from changes to _all_ documents, not just those containing Labels. The reason this wasn't done earlier was because it triggered a different bug, which is also fixed in this PR.

The messages of the commits are reproduced here:

> The frontend is not getting the events from Redis when packages are imported. This is because it was only subscribed to records with Labels, and not all records have them. This commit makes the pattern of the subscription wider, so that all events are sent from the backend.

> The code was assuming that the event data of an updated record/document always contained its Name. But sometimes the pattern may not be a subscription to that specific document, but a more generic one (like Name:"*"), and so in that case, the first pattern may not matched that assumption. This commit updates the code to read the document name from the event's "key" structure instead.

See also the ticket for extra information: [BP-1200](https://movai.atlassian.net/browse/BP-1200)

---

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- ~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1200]: https://movai.atlassian.net/browse/BP-1200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ