### PR TITLE
FP-2972: Define missing node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-2972](https://movai.atlassian.net/browse/FP-2972):Opening flow when nodes don't exist results in stacktrace
+
 # 1.2.9
 
 - [FP-2926](https://movai.atlassian.net/browse/FP-2926): Clear console and app errors

--- a/src/editors/Flow/model/subModels/NodeInstance/NodeInstance.js
+++ b/src/editors/Flow/model/subModels/NodeInstance/NodeInstance.js
@@ -60,7 +60,7 @@ class NodeInstance extends Model {
       }
     );
 
-    this.templateDoc = templateDoc;
+    this.templateDoc = templateDoc ?? {};
     return this;
   }
 


### PR DESCRIPTION
- [FP-2972](https://movai.atlassian.net/browse/FP-2972):Opening flow when nodes don't exist results in stacktrace

[FP-2972]: https://movai.atlassian.net/browse/FP-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ