### PR TITLE
FP-3007: Scene - Search backspace on drawer deletes node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-3007](https://movai.atlassian.net/browse/FP-3007): Scene - Search backspace on drawer deletes node
+
 # 1.4.1
 
 - [FP-2956](https://movai.atlassian.net/browse/FP-2956): Drawers should reflect editor being interacted with in split view mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TBD
 
-- [FP-3007](https://movai.atlassian.net/browse/FP-3007): Scene - Search backspace on drawer deletes node
+- [FP-3001](https://movai.atlassian.net/browse/FP-3001): Clicking backspace on drawer input deletes selected node
 
 # 1.4.1
 

--- a/src/engine/ReactPlugin/EditorReactPlugin.js
+++ b/src/engine/ReactPlugin/EditorReactPlugin.js
@@ -6,7 +6,7 @@ import withLoader from "../../decorators/withLoader";
 import { withDataHandler } from "../../plugins/DocManager/DataHandler";
 import { KEYBINDINGS } from "../../utils/shortcuts";
 import { PLUGINS } from "../../utils/Constants";
-import { useKeyBinds, setUrl } from "../../utils/keybinds";
+import { addKeyBind, setUrl } from "../../utils/keybinds";
 import { composeDecorators } from "../../utils/Utils";
 import { ViewPlugin } from "./ViewReactPlugin";
 
@@ -27,14 +27,13 @@ export function withEditorPlugin(ReactComponent, methods = []) {
 
     const editorContainer = useRef();
 
-    const { addKeyBind, removeKeyBind } = useKeyBinds(id);
-
     /**
      * Activate editor : activate editor's keybinds and update right menu
      */
     const activateEditor = useCallback(() => {
       setUrl(id);
       resetAndUpdateMenus();
+      addKeyBind(KEYBINDINGS.EDITOR_GENERAL.KEYBINDS.SAVE.SHORTCUTS, save);
     }, [id, resetAndUpdateMenus]);
 
     const resetAndUpdateMenus = useCallback(() => {
@@ -47,8 +46,7 @@ export function withEditorPlugin(ReactComponent, methods = []) {
      * Component did mount
      */
     useEffect(() => {
-      addKeyBind(KEYBINDINGS.EDITOR_GENERAL.KEYBINDS.SAVE.SHORTCUTS, save);
-
+      activateEditor();
       on(PLUGINS.TABS.NAME, PLUGINS.TABS.ON.ACTIVE_TAB_CHANGE, async (data) => {
         const validTab = await call(
           PLUGINS.TABS.NAME,
@@ -67,7 +65,6 @@ export function withEditorPlugin(ReactComponent, methods = []) {
 
       // Remove key bind on component unmount
       return () => {
-        removeKeyBind(KEYBINDINGS.EDITOR_GENERAL.KEYBINDS.SAVE.SHORTCUTS);
         off(PLUGINS.TABS.NAME, PLUGINS.TABS.ON.ACTIVE_TAB_CHANGE);
       };
     }, [
@@ -77,7 +74,6 @@ export function withEditorPlugin(ReactComponent, methods = []) {
       id,
       off,
       on,
-      removeKeyBind,
       resetAndUpdateMenus,
       save,
     ]);

--- a/src/plugins/hosts/DrawerPanel/DrawerPanel.jsx
+++ b/src/plugins/hosts/DrawerPanel/DrawerPanel.jsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useState } from "react";
 import PropTypes from "prop-types";
 import { Drawer, Typography } from "@material-ui/core";
 import { DRAWER } from "../../../utils/Constants";
+import { setUrl } from "../../../utils/keybinds";
 import { withHostReactPlugin } from "../../../engine/ReactPlugin/HostReactPlugin";
 import { usePluginMethods } from "../../../engine/ReactPlugin/ViewReactPlugin";
 import withBookmarks, {
@@ -121,7 +122,11 @@ const DrawerPanel = forwardRef((props, ref) => {
       style={{ ...style }}
       className={`${classes.drawer} ${className}`}
     >
-      <Typography component="div" className={classes.content}>
+      <Typography
+        component="div"
+        className={classes.content}
+        onClick={() => setUrl("DrawerPanel/" + anchor)}
+      >
         {activeView === DRAWER.VIEWS.PLUGIN ? viewPlugins : bookmarkView}
       </Typography>
     </Drawer>


### PR DESCRIPTION
- [FP-3001](https://movai.atlassian.net/browse/FP-3001): Clicking backspace on drawer input deletes selected node

- This also make save a global keybind to avoid the shortcut not working with modal or drawer focus
- The branch name was wrong, and this mentioned the scene, which was also an error in part. Although this affects the scene as well, the original ticket did not reference the scene editor.


[FP-3007]: https://movai.atlassian.net/browse/FP-3007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FP-3001]: https://movai.atlassian.net/browse/FP-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ