### PR TITLE
Release 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# TBD
+# 1.4.2
 
 - [FP-3001](https://movai.atlassian.net/browse/FP-3001): Clicking backspace on drawer input deletes selected node
 - [FP-3012](https://movai.atlassian.net/browse/FP-3012): When adding a node, the node list collapses

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mov-ai/mov-fe-lib-ide",
-  "version": "1.4.1-0",
+  "version": "1.4.2-0",
   "keywords": [
     "frontend",
     "ide",


### PR DESCRIPTION
- [FP-3001](https://movai.atlassian.net/browse/FP-3001): Clicking backspace on drawer input deletes selected node
- [FP-3012](https://movai.atlassian.net/browse/FP-3012): When adding a node, the node list collapses


[FP-3001]: https://movai.atlassian.net/browse/FP-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FP-3012]: https://movai.atlassian.net/browse/FP-3012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ