### PR TITLE
Document doesn't get dirty, add Label to pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-2964](https://movai.atlassian.net/browse/FP-2964): IDE - Doc doesn't get dirty when changes are made (so its not saved)
+
 # 1.4.2
 
 - [FP-3001](https://movai.atlassian.net/browse/FP-3001): Clicking backspace on drawer input deletes selected node

--- a/src/store/BaseStore.js
+++ b/src/store/BaseStore.js
@@ -24,7 +24,7 @@ class BaseStore extends StorePluginManager {
     this._scope = model.SCOPE;
     this._name = name || "Store";
     this._title = title || "Generic Store";
-    this.pattern = pattern || { Scope: this.scope, Name: "*" };
+    this.pattern = pattern || { Scope: this.scope, Name: "*", Label: "*" };
     this.observer = observer;
     this.docManager = docManager;
     this.protectedDocs = [];


### PR DESCRIPTION
- [FP-2964](https://movai.atlassian.net/browse/FP-2964): IDE - Doc doesn't get dirty when changes are made (so its not saved)
  - Tested that when installing ROS package, documents show in UI and have content
  - Without label the responses grow in size (10x to 100x)

[FP-2964]: https://movai.atlassian.net/browse/FP-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ