### PR TITLE
FP-3068: FP-3069: Removed scope from Drawers. Voided keybinds on inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-3068](https://movai.atlassian.net/browse/FP-3068): Inconsitencies on Keybindings
+
 # 1.4.2
 
 - [FP-3001](https://movai.atlassian.net/browse/FP-3001): Clicking backspace on drawer input deletes selected node

--- a/src/editors/Flow/view/Components/Explorer/Explorer.jsx
+++ b/src/editors/Flow/view/Components/Explorer/Explorer.jsx
@@ -83,6 +83,25 @@ const Explorer = (props) => {
    *                                                                                      */
   //========================================================================================
 
+  const getFilteredChildren = useCallback(
+    (store) => {
+      return store
+        .getDocs()
+        .filter((d) => !d.isNew && d.id !== Utils.getNameFromURL(flowId));
+    },
+    [flowId],
+  );
+
+  const getFormatedChildren = (filteredChildren) => {
+    return filteredChildren.map((doc, childId) => ({
+      id: childId,
+      name: doc.getName(),
+      title: doc.getName(),
+      scope: doc.getScope(),
+      url: doc.getUrl(),
+    }));
+  };
+
   /**
    * Load documents
    * @param {DocManager} docManager
@@ -93,28 +112,19 @@ const Explorer = (props) => {
         [docManager.getStore("Node"), docManager.getStore("Flow")].map(
           (store, id) => {
             const { name, title } = store;
-            const filteredChildren = store
-              .getDocs()
-              .filter((d) => !d.isNew && d.id !== Utils.getNameFromURL(flowId));
+            const filteredChildren = getFilteredChildren(store);
+
             return {
               id,
               name,
               title,
-              children: filteredChildren.map((doc, childId) => {
-                return {
-                  id: childId,
-                  name: doc.getName(),
-                  title: doc.getName(),
-                  scope: doc.getScope(),
-                  url: doc.getUrl(),
-                };
-              }),
+              children: getFormatedChildren(filteredChildren),
             };
           },
         ),
       );
     },
-    [flowId],
+    [getFilteredChildren],
   );
 
   //========================================================================================
@@ -162,4 +172,7 @@ export default withViewPlugin(Explorer);
 Explorer.propTypes = {
   call: PropTypes.func.isRequired,
   on: PropTypes.func.isRequired,
+  emit: PropTypes.func.isRequired,
+  flowId: PropTypes.string.isRequired,
+  mainInterface: PropTypes.object.isRequired,
 };

--- a/src/editors/Flow/view/Components/Explorer/Explorer.jsx
+++ b/src/editors/Flow/view/Components/Explorer/Explorer.jsx
@@ -71,7 +71,7 @@ const Explorer = (props) => {
    * Handle Mouse Leave on Node
    * @param {NodeObject} node
    */
-  const handleMouseLeaveNode = useCallback((_node) => {
+  const handleMouseLeaveNode = useCallback(() => {
     if (shouldUpdatePreview.current) {
       setSelectedNode({});
     }
@@ -89,7 +89,7 @@ const Explorer = (props) => {
    */
   const loadDocs = useCallback(
     (docManager) => {
-      return setData((_node) =>
+      return setData(() =>
         [docManager.getStore("Node"), docManager.getStore("Flow")].map(
           (store, id) => {
             const { name, title } = store;
@@ -146,6 +146,7 @@ const Explorer = (props) => {
         {data && (
           <ListItemsTreeWithSearch
             data={data}
+            call={call}
             onClickNode={requestScopeVersions}
             onMouseEnter={handleMouseEnterNode}
             onMouseLeave={handleMouseLeaveNode}

--- a/src/editors/Flow/view/Flow.jsx
+++ b/src/editors/Flow/view/Flow.jsx
@@ -1407,6 +1407,13 @@ export const Flow = (props, ref) => {
       },
       KEYBINDINGS.MISC.KEYBINDS.SEARCH_INPUT_CLOSE.SCOPE,
     );
+    addKeyBind(
+      KEYBINDINGS.MISC.KEYBINDS.SEARCH_INPUT_PREVENT_SEARCH.SHORTCUTS,
+      (evt) => {
+        evt.preventDefault();
+      },
+      KEYBINDINGS.MISC.KEYBINDS.SEARCH_INPUT_PREVENT_SEARCH.SCOPE,
+    );
     addKeyBind(KEYBINDINGS.FLOW.KEYBINDS.COPY_NODE.SHORTCUTS, handleCopyNode);
     addKeyBind(
       KEYBINDINGS.FLOW.KEYBINDS.PASTE_NODE.SHORTCUTS,

--- a/src/editors/Flow/view/Flow.jsx
+++ b/src/editors/Flow/view/Flow.jsx
@@ -64,6 +64,7 @@ export const Flow = (props, ref) => {
     alert,
     confirmationAlert,
     contextOptions,
+    activateEditor,
     on,
     off,
   } = props;
@@ -614,10 +615,6 @@ export const Flow = (props, ref) => {
     getLinkMenuToAdd,
   ]);
 
-  usePluginMethods(ref, {
-    renderMenus,
-  });
-
   //========================================================================================
   /*                                                                                      *
    *                                     Handle Events                                    *
@@ -710,10 +707,11 @@ export const Flow = (props, ref) => {
           selectedNodeRef.current = node;
           activeBookmark = MENUS.current.NODE.NAME;
           addNodeMenu(node, true);
+          activateEditor();
         }
       }, 300);
     },
-    [addNodeMenu, unselectNode, onLinkSelected],
+    [addNodeMenu, unselectNode, onLinkSelected, activateEditor],
   );
 
   /**
@@ -725,6 +723,7 @@ export const Flow = (props, ref) => {
       selectedLinkRef.current = link;
       getMainInterface().selectedLink = link;
       if (!link) {
+        activeBookmark = MENUS.current.DETAIL.NAME;
         call(
           PLUGINS.RIGHT_DRAWER.NAME,
           PLUGINS.RIGHT_DRAWER.CALL.REMOVE_BOOKMARK,
@@ -753,9 +752,11 @@ export const Flow = (props, ref) => {
 
         activeBookmark = MENUS.current.LINK.NAME;
         addLinkMenu(link, true);
+
+        activateEditor();
       }
     },
-    [call, unselectNode, addLinkMenu],
+    [call, unselectNode, addLinkMenu, activateEditor],
   );
 
   /**
@@ -1459,6 +1460,11 @@ export const Flow = (props, ref) => {
     handleSearchDisabled,
   ]);
 
+  usePluginMethods(ref, {
+    renderMenus,
+    setFlowsToDefault,
+  });
+
   //========================================================================================
   /*                                                                                      *
    *                                        Render                                        *
@@ -1527,12 +1533,15 @@ Flow.propTypes = {
   scope: PropTypes.string.isRequired,
   call: PropTypes.func.isRequired,
   on: PropTypes.func.isRequired,
+  off: PropTypes.func.isRequired,
   data: PropTypes.object,
   instance: PropTypes.object,
   editable: PropTypes.bool,
   alert: PropTypes.func,
   confirmationAlert: PropTypes.func,
   saveDocument: PropTypes.func,
+  activateEditor: PropTypes.func,
+  contextOptions: PropTypes.func,
 };
 
 export default withEditorPlugin(Flow);

--- a/src/engine/ReactPlugin/EditorReactPlugin.js
+++ b/src/engine/ReactPlugin/EditorReactPlugin.js
@@ -14,7 +14,7 @@ import { ViewPlugin } from "./ViewReactPlugin";
  * @param {Array<String>} methods : Methods to be exposed
  * @returns
  */
-export function withEditorPlugin(ReactComponent, methods = []) {
+export function withEditorPlugin(ReactComponent) {
   const RefComponent = forwardRef((props, ref) => ReactComponent(props, ref));
 
   /**
@@ -63,7 +63,12 @@ export function withEditorPlugin(ReactComponent, methods = []) {
         className={`container-${scope}`}
         onClick={activateEditor}
       >
-        <RefComponent {...props} saveDocument={save} ref={ref} />
+        <RefComponent
+          {...props}
+          saveDocument={save}
+          ref={ref}
+          activateEditor={activateEditor}
+        />
       </div>
     );
   });
@@ -80,7 +85,10 @@ export function withEditorPlugin(ReactComponent, methods = []) {
    */
   return class extends ViewPlugin {
     constructor(profile, props = {}) {
-      super(profile, props, methods);
+      const editorExposedMethods = [
+        ...Object.values(PLUGINS.EDITOR[props.scope.toUpperCase()]?.CALL ?? {}),
+      ];
+      super(profile, props, editorExposedMethods);
     }
 
     render(otherProps) {

--- a/src/engine/ReactPlugin/EditorReactPlugin.js
+++ b/src/engine/ReactPlugin/EditorReactPlugin.js
@@ -37,7 +37,7 @@ export function withEditorPlugin(ReactComponent) {
       setUrl(id);
       addKeyBind(KEYBINDINGS.EDITOR_GENERAL.KEYBINDS.SAVE.SHORTCUTS, save);
 
-      if (activeTab.id !== id) {
+      if (activeTab?.id !== id) {
         call(PLUGINS.TABS.NAME, PLUGINS.TABS.CALL.FOCUS_EXISTING_TAB, id);
       }
     }, [call, id, save]);

--- a/src/engine/ReactPlugin/ToolReactPlugin.js
+++ b/src/engine/ReactPlugin/ToolReactPlugin.js
@@ -40,7 +40,7 @@ export function withToolPlugin(ReactComponent, methods = []) {
 
       setUrl(profile.name);
 
-      if (activeTab.id !== id) {
+      if (activeTab?.id !== id) {
         call(PLUGINS.TABS.NAME, PLUGINS.TABS.CALL.FOCUS_EXISTING_TAB, id);
       }
     }, [call, profile.name]);

--- a/src/plugins/Orchestrator/Orchestrator.ts
+++ b/src/plugins/Orchestrator/Orchestrator.ts
@@ -1,6 +1,5 @@
 import { Profile } from "@remixproject/plugin-utils";
 import { PLUGINS } from "../../utils/Constants";
-import { setUrl } from "../../utils/keybinds";
 import PluginManagerIDE from "../../engine/PluginManagerIDE/PluginManagerIDE";
 import IDEPlugin from "../../engine/IDEPlugin/IDEPlugin";
 

--- a/src/plugins/hosts/DrawerPanel/DrawerPanel.jsx
+++ b/src/plugins/hosts/DrawerPanel/DrawerPanel.jsx
@@ -2,7 +2,6 @@ import React, { forwardRef, useState } from "react";
 import PropTypes from "prop-types";
 import { Drawer, Typography } from "@material-ui/core";
 import { DRAWER } from "../../../utils/Constants";
-import { setUrl } from "../../../utils/keybinds";
 import { withHostReactPlugin } from "../../../engine/ReactPlugin/HostReactPlugin";
 import { usePluginMethods } from "../../../engine/ReactPlugin/ViewReactPlugin";
 import withBookmarks, {
@@ -122,11 +121,7 @@ const DrawerPanel = forwardRef((props, ref) => {
       style={{ ...style }}
       className={`${classes.drawer} ${className}`}
     >
-      <Typography
-        component="div"
-        className={classes.content}
-        onClick={() => setUrl("DrawerPanel/" + anchor)}
-      >
+      <Typography component="div" className={classes.content}>
         {activeView === DRAWER.VIEWS.PLUGIN ? viewPlugins : bookmarkView}
       </Typography>
     </Drawer>

--- a/src/plugins/views/Explorer/Explorer.jsx
+++ b/src/plugins/views/Explorer/Explorer.jsx
@@ -324,6 +324,7 @@ const Explorer = (props) => {
         {data && (
           <ListItemsTreeWithSearch
             data={data}
+            call={call}
             onClickNode={requestScopeVersions}
             handleCopyClick={handleCopy}
             handleDeleteClick={handleDelete}

--- a/src/plugins/views/Explorer/components/ListItemTree/ListItemsTreeWithSearch.jsx
+++ b/src/plugins/views/Explorer/components/ListItemTree/ListItemsTreeWithSearch.jsx
@@ -137,7 +137,7 @@ const ListItemsTreeWithSearch = (props) => {
       PLUGINS.TABS.CALL.GET_ACTIVE_TAB,
     );
 
-    if (activeTab.scope === "Flow") {
+    if (activeTab?.scope === "Flow") {
       await call(activeTab.id, PLUGINS.EDITOR.FLOW.CALL.SET_FLOW_TO_DEFAULT);
     }
   };

--- a/src/plugins/views/Explorer/components/ListItemTree/ListItemsTreeWithSearch.jsx
+++ b/src/plugins/views/Explorer/components/ListItemTree/ListItemsTreeWithSearch.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { Divider, List, ListItem } from "@material-ui/core";
+import { PLUGINS } from "../../../../../utils/Constants";
 import Search from "../../../../../utils/components/Search/Search";
 import VirtualizedTree from "../VirtualizedTree/VirtualizedTree";
 
@@ -29,7 +30,7 @@ export function toggleExpandRow(node, data) {
 }
 
 const ListItemsTreeWithSearch = (props) => {
-  const { data } = props;
+  const { data, call } = props;
 
   // State hooks
   const [itemData, setItemData] = useState([]);
@@ -126,6 +127,21 @@ const ListItemsTreeWithSearch = (props) => {
     setItemData(searchFilter(data, searchValue));
   };
 
+  /**
+   * Search handler
+   * @param {String} searchValue : String used to search
+   */
+  const handleOnFocus = async () => {
+    const activeTab = await call(
+      PLUGINS.TABS.NAME,
+      PLUGINS.TABS.CALL.GET_ACTIVE_TAB,
+    );
+
+    if (activeTab.scope === "Flow") {
+      await call(activeTab.id, PLUGINS.EDITOR.FLOW.CALL.SET_FLOW_TO_DEFAULT);
+    }
+  };
+
   //========================================================================================
   /*                                                                                      *
    *                                    React Lifecycle                                   *
@@ -160,7 +176,7 @@ const ListItemsTreeWithSearch = (props) => {
   return (
     <List className={classes.list} dense={true} component="div">
       <ListItem className={classes.searchHolder} component="div">
-        <Search onSearch={handleOnSearch} />
+        <Search onSearch={handleOnSearch} onFocus={handleOnFocus} />
       </ListItem>
       <Divider />
       <div className={classes.listHolder}>

--- a/src/plugins/views/Explorer/components/ListItemTree/ListItemsTreeWithSearch.jsx
+++ b/src/plugins/views/Explorer/components/ListItemTree/ListItemsTreeWithSearch.jsx
@@ -71,6 +71,17 @@ const ListItemsTreeWithSearch = (props) => {
     return finalData;
   }
 
+  const getFormatedChildren = (child, i) => {
+    child.id = child.id ?? i;
+    child.url = child.url ?? child.id;
+    if (child.children) {
+      child.children.forEach((grandChild, j) => {
+        grandChild.id = grandChild.id ?? j;
+        grandChild.url = grandChild.url ?? grandChild.id;
+      });
+    }
+  };
+
   /**
    * Filters given array of data
    * @param {Array} searchData : data that we want to filter from
@@ -89,24 +100,15 @@ const ListItemsTreeWithSearch = (props) => {
       .map((node) => {
         return {
           ...node,
-          children: (node.children ?? []).filter(
-            (ch) => ch.name && ch.name.toLowerCase().includes(valueLower),
+          children: (node.children ?? []).filter((ch) =>
+            ch.name?.toLowerCase().includes(valueLower),
           ),
         };
       });
 
     // Add children id if missing
     filteredNodes.forEach((node) => {
-      node.children.forEach((child, i) => {
-        child.id = child.id ?? i;
-        child.url = child.url ?? child.id;
-        if (child.children) {
-          child.children.forEach((grandChild, j) => {
-            grandChild.id = grandChild.id ?? j;
-            grandChild.url = grandChild.url ?? grandChild.id;
-          });
-        }
-      });
+      node.children.forEach(getFormatedChildren);
     });
 
     return normalizeData(filteredNodes);
@@ -188,6 +190,7 @@ const ListItemsTreeWithSearch = (props) => {
 
 ListItemsTreeWithSearch.propTypes = {
   data: PropTypes.array.isRequired,
+  call: PropTypes.func.isRequired,
 };
 
 export default ListItemsTreeWithSearch;

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -182,6 +182,14 @@ export const PLUGINS = {
   SYSTEM_BAR: {
     NAME: "systemBar",
   },
+  // Exposed editor methods
+  EDITOR: {
+    FLOW: {
+      CALL: {
+        SET_FLOW_TO_DEFAULT: "setFlowsToDefault",
+      },
+    },
+  },
 };
 
 export const KEYBIND_SCOPES = {

--- a/src/utils/components/Search/Search.jsx
+++ b/src/utils/components/Search/Search.jsx
@@ -72,7 +72,7 @@ function filter(searchQuery, subject) {
 }
 
 const Search = (props) => {
-  const { onSearch } = props;
+  const { onSearch, onFocus } = props;
 
   // State hooks
   const [searchInput, setSearchInput] = useState("");
@@ -128,6 +128,7 @@ const Search = (props) => {
       placeholder={i18n.t("Search")}
       value={searchInput}
       onChange={onChangeSearch}
+      onFocus={onFocus}
       inputProps={{ "data-testid": "input_search" }}
       InputProps={{
         endAdornment: (

--- a/src/utils/components/Search/Search.jsx
+++ b/src/utils/components/Search/Search.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import PropTypes from "prop-types";
 import { i18n } from "@mov-ai/mov-fe-lib-react";
 import SearchIcon from "@material-ui/icons/Search";
 import ClearIcon from "@material-ui/icons/Clear";
@@ -43,7 +44,7 @@ function filter(searchQuery, subject) {
       subject = normalizeString(subject);
       return subject.includes(searchQuery);
 
-    case DATA_TYPES.OBJECT:
+    case DATA_TYPES.OBJECT: {
       // Is array
       if (Array.isArray(subject)) {
         subject = subject?.filter((e) => {
@@ -59,7 +60,9 @@ function filter(searchQuery, subject) {
       // Is an object
       const values = Object.values(subject || {});
       const list = filter(searchQuery, values);
+
       return list.length > 0 ? subject : false;
+    }
 
     case DATA_TYPES.NUMBER:
       return searchNonStrings();
@@ -151,6 +154,11 @@ const Search = (props) => {
       }}
     />
   );
+};
+
+Search.propTypes = {
+  onSearch: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
 };
 
 export default Search;

--- a/src/utils/keybinds.js
+++ b/src/utils/keybinds.js
@@ -75,24 +75,6 @@ export function getCurrentUrl() {
 }
 
 /**
- * If it's an input we always want to keep the default browser behaviour
- * Unless it specifically defined that it should have keybinds (data-scope)
- * @param {Element} target
- * @returns {boolean}
- */
-function shouldVoidKeybinds(target) {
-  return (
-    !target.getAttribute("data-scope") &&
-    // if it is an input
-    (target.tagName === "INPUT" ||
-      // or a textarea
-      target.tagName === "TEXTAREA" ||
-      // or a MUI option
-      target.role === "option")
-  );
-}
-
-/**
  * this handles calling callbacks that correspond
  * to user key combinations
  */
@@ -101,12 +83,7 @@ globalThis.addEventListener("keydown", (evt) => {
   const path = composePath(scopeUrl, dataScope);
   const kbs = { ...(keybinds[path] ?? {}), ...keybinds["/"] };
 
-  if (
-    shouldVoidKeybinds(evt.target) ||
-    evt.key === "Control" ||
-    evt.key === "Alt"
-  )
-    return;
+  if (evt.key === "Control" || evt.key === "Alt") return;
 
   for (const key of Object.keys(kbs)) {
     const splits = key.split("+").reduce(

--- a/src/utils/keybinds.js
+++ b/src/utils/keybinds.js
@@ -75,15 +75,38 @@ export function getCurrentUrl() {
 }
 
 /**
+ * If it's an input we always want to keep the default browser behaviour
+ * Unless it specifically defined that it should have keybinds (data-scope)
+ * @param {Element} target
+ * @returns {boolean}
+ */
+function shouldVoidKeybinds(target) {
+  return (
+    !target.getAttribute("data-scope") &&
+    // if it is an input
+    (target.tagName === "INPUT" ||
+      // or a textarea
+      target.tagName === "TEXTAREA" ||
+      // or a MUI option
+      target.role === "option")
+  );
+}
+
+/**
  * this handles calling callbacks that correspond
  * to user key combinations
  */
 globalThis.addEventListener("keydown", (evt) => {
   const dataScope = evt.target.getAttribute("data-scope");
-  const path = scopeUrl + (dataScope ?? "");
+  const path = composePath(scopeUrl, dataScope);
   const kbs = { ...(keybinds[path] ?? {}), ...keybinds["/"] };
 
-  if (evt.key === "Control" || evt.key === "Alt") return;
+  if (
+    shouldVoidKeybinds(evt.target) ||
+    evt.key === "Control" ||
+    evt.key === "Alt"
+  )
+    return;
 
   for (const key of Object.keys(kbs)) {
     const splits = key.split("+").reduce(


### PR DESCRIPTION
[FP-3068](https://movai.atlassian.net/browse/FP-3068)
[FP-3069](https://movai.atlassian.net/browse/FP-3069)

* Removed keybind scope from drawers as that was causing some regressions.
* ~Voided keybinds when we are focusing an input / textarea / select unless it strictly has data-scope.~
* Fixed an issue where scope wasn't working because it was lacking a "/".
* Added the keybind on flow search to prevent the popping of browser search when we were typing.
* Now when we select the explorer text input node / link selection will be unselected as to solve #367 
* If for some reason you were able to unselect a link without clicking on the flow, although the link bookmark would disappear, the menu would still show the link information and wouldn't select the details (since the bookmark disappeared we should default to selecting the Details bookmark / menu) - This is now fixed.
* Fixed a couple of small issues that I noticed were happening in split view:
  * If you have a callback on top and a flow on bottom (split view) you could:
    * Click on the callback, the callback would should on the drawer, then click on the flow and the flow would show on the drawer.
    * If you selected the callback and then clicked on a node / link weird things happened. The node / link menu and bookmark would show, but the drawer was effectively still the callback, so if you go to the "details" bookmark you'd see all the details related to the callback. This issue was fixed.

~**THIS FIX NEEDS TO BE DISCUSSED. IT RE-INTRODUCES THIS [ISSUE](https://github.com/MOV-AI/frontend-npm-lib-ide/pull/367)**~

[FP-3068]: https://movai.atlassian.net/browse/FP-3068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FP-3069]: https://movai.atlassian.net/browse/FP-3069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ