### PR TITLE
FP-2639: Mantain state of explorer drawer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-2639](https://movai.atlassian.net/browse/FP-2639): IDE - Explorer windows popping up when switching to Get Started
+
 # v1.4.5
 
 - [FP-1013](https://movai.atlassian.net/browse/FP-1013): IDE - Optimize Flow shift select nodes

--- a/src/plugins/hosts/DrawerPanel/DrawerPanel.jsx
+++ b/src/plugins/hosts/DrawerPanel/DrawerPanel.jsx
@@ -18,13 +18,11 @@ const DrawerPanel = forwardRef((props, ref) => {
     anchor,
     initialOpenState,
     className,
-    length,
     children: bookmarkView,
   } = props;
   const [open, setOpen] = useState(initialOpenState);
   const [activeView, setActiveView] = useState(DRAWER.VIEWS.PLUGIN);
-  const realOpen = open && (anchor === "left" || length);
-  const classes = drawerPanelStyles(anchor === "left", realOpen)();
+  const classes = drawerPanelStyles(anchor === "left", open)();
 
   //========================================================================================
   /*                                                                                      *
@@ -84,7 +82,6 @@ const DrawerPanel = forwardRef((props, ref) => {
    */
   const resetDrawer = () => {
     setActiveView(DRAWER.VIEWS.PLUGIN);
-    setOpen(initialOpenState);
   };
 
   //========================================================================================
@@ -115,7 +112,7 @@ const DrawerPanel = forwardRef((props, ref) => {
   return (
     <Drawer
       id={hostName}
-      open={realOpen}
+      open={open}
       anchor={anchor}
       variant="persistent"
       style={{ ...style }}
@@ -140,7 +137,12 @@ export default withHostReactPlugin(
 
 DrawerPanel.propTypes = {
   hostName: PropTypes.string.isRequired,
+  anchor: PropTypes.string.isRequired,
+  className: PropTypes.string,
   initialOpenState: PropTypes.bool,
+  style: PropTypes.object,
+  children: PropTypes.object,
+  viewPlugins: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
 };
 
 DrawerPanel.defaultProps = {


### PR DESCRIPTION
[FP-2639](https://movai.atlassian.net/browse/FP-2639)

* Mantain state of explorer drawer.
* In the case of the scene, if the user enters a scene, the default Scene Tree explorer will be selected (although open/close state will be mantained). If it's open and the user changes to another tab (that doesn't have Scene Tree explorer), the normal Explorer will be loaded.

[FP-2639]: https://movai.atlassian.net/browse/FP-2639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ