### PR TITLE
FP-3050:  Configurations: Toggle between XML and YAML isn't highlighting in real-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-3050](https://movai.atlassian.net/browse/FP-3050): Configurations: Toggle between XML and YAML isn't highlighting in real-time
+
 # v1.4.5
 
 - [FP-1013](https://movai.atlassian.net/browse/FP-1013): IDE - Optimize Flow shift select nodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 - [FP-1013](https://movai.atlassian.net/browse/FP-1013): IDE - Optimize Flow shift select nodes
 - [FP-2644](https://movai.atlassian.net/browse/FP-2644): UI is frozen in certain split configurations in the IDE
 - [FP-2988](https://movai.atlassian.net/browse/FP-2988): Can't create Callback from node subscriber port "+" button
+- [FP-3080](https://movai.atlassian.net/browse/FP-3080): IDE - Fix Node preview banner width
 
 # v1.4.4
 
-- [FP-3080](https://movai.atlassian.net/browse/FP-3080): IDE - Fix Node preview banner width
 - [FP-3027](https://movai.atlassian.net/browse/FP-3027): IDE - Hide container configuration on nodes
 - [FP-2964](https://movai.atlassian.net/browse/FP-2964): IDE - Doc doesn't get dirty when changes are made (so its not saved)
 

--- a/src/editors/Configuration/view/Configuration.jsx
+++ b/src/editors/Configuration/view/Configuration.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { i18n } from "@mov-ai/mov-fe-lib-react";
 import { MonacoCodeEditor } from "@mov-ai/mov-fe-lib-code-editor";
@@ -31,6 +31,7 @@ export const Configuration = (props, ref) => {
     propsData: props.data,
     keysToDisconsider: Model.KEYS_TO_DISCONSIDER,
   });
+  const [extension, setExtension] = useState("yaml");
   // Style Hooks
   const classes = configurationStyles();
   const theme = useTheme();
@@ -99,6 +100,7 @@ export const Configuration = (props, ref) => {
    */
   const handleChangeFileType = (event, newExtension) => {
     event.stopPropagation();
+    setExtension(newExtension);
     updateConfigExtension(newExtension);
   };
 
@@ -116,7 +118,7 @@ export const Configuration = (props, ref) => {
    *                                                                                      */
   //========================================================================================
 
-  const renderEditor = () => {
+  const editorEl = useMemo(() => {
     return (
       <div
         data-testid="section_configuration-editor"
@@ -124,7 +126,7 @@ export const Configuration = (props, ref) => {
       >
         <MonacoCodeEditor
           value={data.code}
-          language={data.extension}
+          language={extension}
           theme={theme.codeEditor?.theme}
           options={{ readOnly: !editable }}
           onChange={updateConfigCode}
@@ -133,7 +135,7 @@ export const Configuration = (props, ref) => {
         />
       </div>
     );
-  };
+  }, [extension, classes.codeContainer, data.code]);
 
   return (
     <div
@@ -157,7 +159,7 @@ export const Configuration = (props, ref) => {
           </ToggleButtonGroup>
         </Toolbar>
       </AppBar>
-      {renderEditor()}
+      {editorEl}
     </div>
   );
 };


### PR DESCRIPTION
- [FP-3050](https://movai.atlassian.net/browse/FP-3050): Configurations: Toggle between XML and YAML isn't highlighting in real-time

Needs:
https://github.com/MOV-AI/frontend-npm-lib-code-editor/pull/89

[FP-3050]: https://movai.atlassian.net/browse/FP-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ