### PR TITLE
FP-3141: Changed DISABLED_VALUE constant from None to {{DISABLED_VALUE}}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # TBD
 
+- [FP-3141](https://movai.atlassian.net/browse/FP-3141): Unable to update node parameter if the first value saved as None
 - [FP-3138](https://movai.atlassian.net/browse/FP-3138): Not able to use dev container in all frontend repos
 
 # v1.4.6

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -7,7 +7,7 @@ export const APP_CUSTOM_CONFIG = "app-custom-ide-ce";
 export const MANAGER = "manager";
 
 export const DEFAULT_VALUE = undefined;
-export const DISABLED_VALUE = "None";
+export const DISABLED_VALUE = "{{DISABLED_VALUE}}";
 
 export const DATA_TYPES = {
   CONFIGURATION: "config",


### PR DESCRIPTION
[FP-3141](https://movai.atlassian.net/browse/FP-3141)

* Changed DISABLED_VALUE constant from None to {{DISABLED_VALUE}}


**I'm positive that this will affect previously set Disabled Values. They will not show as disabled in all the Flows / Node instances, but they will show as None instead. Any suggestions on how to fix this?** - @diasnad @diasdm 

[FP-3141]: https://movai.atlassian.net/browse/FP-3141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ