### PR TITLE
FP-3081: Handling port modal state manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-3081](https://movai.atlassian.net/browse/FP-3081): Port Modal lingers frequently
+
 # 2.6.2
 
 - [FP-3212](https://movai.atlassian.net/browse/FP-3212): Unable to create a type Array flow parameter with a list of strings

--- a/src/editors/Flow/view/Components/Nodes/BaseNode/BasePort.js
+++ b/src/editors/Flow/view/Components/Nodes/BaseNode/BasePort.js
@@ -87,6 +87,7 @@ class BasePort extends BasePortStruct {
       .attr("r", this.radius)
       .attr("stroke-width", 0)
       .attr("class", css)
+      .attr("id", `${this.data.name}_port`)
       .attr("data-testid", this.data.name);
 
     return this;

--- a/src/editors/Flow/view/Components/Tooltips/PortTooltip.jsx
+++ b/src/editors/Flow/view/Components/Tooltips/PortTooltip.jsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles(() => ({
 
 const PortTooltip = (props) => {
   const classes = useStyles();
-  const { anchorPosition, port } = props;
+  const { anchorPosition, port, handleCloseTooltip } = props;
   const title = i18n.t("Port");
 
   const itemTextProps = {
@@ -47,9 +47,12 @@ const PortTooltip = (props) => {
 
   return (
     <Paper
+      id={`${port.data.name}_tooltip`}
       style={{ ...anchorPosition }}
       className={classes.root}
       elevation={14}
+      onMouseOver={() => handleCloseTooltip(`${port.data.name}_tooltip`)}
+      onMouseOut={() => handleCloseTooltip(null, 300)}
     >
       <List
         dense={true}
@@ -77,6 +80,7 @@ PortTooltip.propTypes = {
     top: PropTypes.number,
   }).isRequired,
   port: PropTypes.object.isRequired,
+  handleCloseTooltip: PropTypes.function.isRequired,
 };
 
 PortTooltip.defaultProps = {};

--- a/src/editors/Flow/view/Components/Tooltips/PortTooltip.jsx
+++ b/src/editors/Flow/view/Components/Tooltips/PortTooltip.jsx
@@ -3,11 +3,13 @@ import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/styles";
 import { i18n } from "@mov-ai/mov-fe-lib-react";
 import { Divider } from "@material-ui/core";
-import PortTooltipContent from "./PortTooltipContent";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Paper from "@material-ui/core/Paper";
+
+import { PORT_TOOLTIP_MODAL_TIMEOUTS } from "../../Constants/constants";
+import PortTooltipContent from "./PortTooltipContent";
 
 const ITEMS_INDEX = "tooltip-fragment-row";
 
@@ -52,7 +54,9 @@ const PortTooltip = (props) => {
       className={classes.root}
       elevation={14}
       onMouseOver={() => handleCloseTooltip(`${port.data.name}_tooltip`)}
-      onMouseOut={() => handleCloseTooltip(null, 300)}
+      onMouseOut={() =>
+        handleCloseTooltip(null, PORT_TOOLTIP_MODAL_TIMEOUTS.FORCE_CLOSE)
+      }
     >
       <List
         dense={true}
@@ -80,7 +84,7 @@ PortTooltip.propTypes = {
     top: PropTypes.number,
   }).isRequired,
   port: PropTypes.object.isRequired,
-  handleCloseTooltip: PropTypes.function.isRequired,
+  handleCloseTooltip: PropTypes.func.isRequired,
 };
 
 PortTooltip.defaultProps = {};

--- a/src/editors/Flow/view/Constants/constants.js
+++ b/src/editors/Flow/view/Constants/constants.js
@@ -45,6 +45,11 @@ const generateContainerId = (flowId) => {
 
 const PARENT_NODE_SEP = "^";
 
+const PORT_TOOLTIP_MODAL_TIMEOUTS = {
+  NORMAL: 3000,
+  FORCE_CLOSE: 100,
+};
+
 export {
   MAX_MOVING_PIXELS,
   CANVAS_LIMITS,
@@ -54,4 +59,5 @@ export {
   MOVAI_FLOW_TYPES,
   NODE_TYPES,
   TYPES,
+  PORT_TOOLTIP_MODAL_TIMEOUTS,
 };

--- a/src/editors/Flow/view/Flow.jsx
+++ b/src/editors/Flow/view/Flow.jsx
@@ -42,7 +42,11 @@ import InvalidLinksWarning from "./Components/Warnings/InvalidLinksWarning";
 import InvalidParametersWarning from "./Components/Warnings/InvalidParametersWarning";
 import InvalidExposedPortsWarning from "./Components/Warnings/InvalidExposedPortsWarning";
 import { EVT_NAMES, EVT_TYPES } from "./events";
-import { FLOW_VIEW_MODE, TYPES } from "./Constants/constants";
+import {
+  FLOW_VIEW_MODE,
+  TYPES,
+  PORT_TOOLTIP_MODAL_TIMEOUTS,
+} from "./Constants/constants";
 import GraphBase from "./Core/Graph/GraphBase";
 import GraphTreeView from "./Core/Graph/GraphTreeView";
 import { getBaseContextOptions } from "./contextOptions";
@@ -711,7 +715,7 @@ export const Flow = (props, ref) => {
           addNodeMenu(node, true);
           activateEditor();
         }
-      }, 300);
+      }, 100);
     },
     [addNodeMenu, unselectNode, onLinkSelected, activateEditor],
   );
@@ -790,28 +794,31 @@ export const Flow = (props, ref) => {
   /**
    * Used to handle the port tooltip closing
    */
-  const handleCloseTooltip = useCallback((hoveredId, timer = 3000) => {
-    lastHoveredIdRef.current = hoveredId;
-    clearTimeout(tooltipConfigTimerRef.current);
+  const handleCloseTooltip = useCallback(
+    (hoveredId, timer = PORT_TOOLTIP_MODAL_TIMEOUTS.NORMAL) => {
+      lastHoveredIdRef.current = hoveredId;
+      clearTimeout(tooltipConfigTimerRef.current);
 
-    tooltipConfigTimerRef.current = setTimeout(() => {
-      const bubbledUpHoveredElements = document.querySelectorAll(":hover");
+      tooltipConfigTimerRef.current = setTimeout(() => {
+        const bubbledUpHoveredElements = document.querySelectorAll(":hover");
 
-      const checkIfIdInHoveredElements = [...bubbledUpHoveredElements].find(
-        (el) =>
-          el.id === `${lastHoveredIdRef.current}_port` ||
-          el.id === `${lastHoveredIdRef.current}_tooltip`,
-      );
+        const checkIfIdInHoveredElements = [...bubbledUpHoveredElements].find(
+          (el) =>
+            el.id === `${lastHoveredIdRef.current}_port` ||
+            el.id === `${lastHoveredIdRef.current}_tooltip`,
+        );
 
-      if (!hoveredId && !checkIfIdInHoveredElements) {
-        setTooltipConfig(null);
-        tooltipConfigTimerRef.current = null;
-        lastHoveredIdRef.current = null;
-      } else {
-        handleCloseTooltip(hoveredId);
-      }
-    }, timer);
-  }, []);
+        if (!hoveredId && !checkIfIdInHoveredElements) {
+          setTooltipConfig(null);
+          tooltipConfigTimerRef.current = null;
+          lastHoveredIdRef.current = null;
+        } else {
+          handleCloseTooltip(hoveredId);
+        }
+      }, timer);
+    },
+    [],
+  );
 
   /**
    * Subscribe to mainInterface and canvas events
@@ -1104,7 +1111,9 @@ export const Flow = (props, ref) => {
                 event.type === EVT_TYPES.PORT,
             ),
           )
-          .subscribe(() => handleCloseTooltip(null, 300)),
+          .subscribe(() =>
+            handleCloseTooltip(null, PORT_TOOLTIP_MODAL_TIMEOUTS.FORCE_CLOSE),
+          ),
       );
 
       interfaceSubscriptionsList.current.push(


### PR DESCRIPTION
[FP-3081](https://movai.atlassian.net/browse/FP-3081)

* We are now handling port modal state manually.
* The port will take 100 ms to close if we just leave out of the port, or 3000 ms when we hover the port (this is the real fix). If we are still hovering the port, it will call for more 3000 ms timeout. If not, it doesn't stay open, it will close after said 3000 ms
* It's so much more controllable now, to the point that I added the ability to also hover over the port tooltip itself. So it will stay opened if the user wants to select any text inside it.
* These values can be adjusted (ofc)

[FP-3081]: https://movai.atlassian.net/browse/FP-3081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ