### PR TITLE
FP-3254: Added instructions to the ROS_VALID_NAMES const errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [FP-3254](https://movai.atlassian.net/browse/FP-3254): Inconsistent error message when creating node with invalid name
+
 # 2.6.2
 
 - [FP-3212](https://movai.atlassian.net/browse/FP-3212): Unable to create a type Array flow parameter with a list of strings

--- a/src/editors/Flow/view/Core/Graph/GraphValidator.js
+++ b/src/editors/Flow/view/Core/Graph/GraphValidator.js
@@ -11,6 +11,7 @@ import MESSAGES from "../../../../../utils/Messages";
 import {
   ROS_VALID_NAMES,
   ALERT_SEVERITIES,
+  ROS_VALID_NAMES_INSTRUCTION,
 } from "../../../../../utils/Constants";
 import { defaultFunction } from "../../../../../utils/Utils";
 import { MisMatchMessageLink } from "../../Components/Links/Errors";
@@ -280,9 +281,9 @@ export default class GraphValidator {
         );
       if (!re.test(newName))
         throw new Error(
-          i18n.t(MESSAGES.ERROR_MESSAGES.INVALID_INSTANCE_NAME, {
+          `${i18n.t(MESSAGES.ERROR_MESSAGES.INVALID_INSTANCE_NAME, {
             instance: instType,
-          }),
+          })} - ${i18n.t(ROS_VALID_NAMES_INSTRUCTION)}`,
         );
       if (this.graph.nodes.has(newName))
         throw new Error(

--- a/src/i18n/languages/en.json
+++ b/src/i18n/languages/en.json
@@ -222,6 +222,7 @@
   "RobotOffline": "Robot is offline",
   "RobotOnline": "Robot is online",
   "Run": "Run",
+  "ROSValidNamesInstruction": "Please enter a name that starts with a letter, tilde (~), or slash (/), contains only letters, numbers, underscores (_), or slashes (/), and does not include double underscores (__).",
   "Save": "Save",
   "SaveDoc": "Save Document",
   "SaveDocKeybindDescription": "Use to save currently active Document.",

--- a/src/i18n/languages/pt.json
+++ b/src/i18n/languages/pt.json
@@ -222,6 +222,8 @@
   "RobotOffline": "O Robot está desligado",
   "RobotOnline": "O Robot está ligado",
   "Run": "Correr",
+  "Run": "Run",
+  "ROSValidNamesInstruction": "Por favor, introduza um nome que comece por uma letra, til (~) ou barra (/), que contenha apenas letras, números, sublinhados (_) ou barras (/), e que não inclua dois sublinhados seguidos (__).",
   "Save": "Salvar",
   "SaveDoc": "Salvar Documento",
   "SaveDocKeybindDescription": "Use para salvar o Documento activo.",

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -242,6 +242,13 @@ export const ROS_VALID_NAMES = new RegExp(
 );
 
 /**
+ * Use this when you're trying to pass instructions to the user how to handle the above ROS_VALID_NAMES validation
+ * If you alter the ROS_VALID_NAMES const please update this warning accordingly
+ * This is the translation string
+ */
+export const ROS_VALID_NAMES_INSTRUCTION = "ROSValidNamesInstruction";
+
+/**
  * Used for Parameters, Environment Variables and Command Line
  * We’re using a variation of the valid ROS validation which only allows for a name to begin with a letter,
  * tilde (~) or a forward slash (/), but also allowing the first character to be an underscore (_),


### PR DESCRIPTION
[FP-3254](https://movai.atlassian.net/browse/FP-3254)

* Added instructions to the ROS_VALID_NAMES const errors

[FP-3254]: https://movai.atlassian.net/browse/FP-3254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ